### PR TITLE
PL-1441 Enable metrics formatted for Prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ I et Java-IDE kjør `SelvbetjeningOpptjeningApplication`.
 #### Applikasjonshelse (usikrede):
 * Liveness: http://localhost:8080/api/internal/isAlive
 * Readiness: http://localhost:8080/api/internal/isReady
-* Helse: http://localhost:8080/mgmt/health
+* Helse: http://localhost:8080/api/mgmt/health
 
-#### Metrikker (usikrede):
-* Liste over metrikker: http://localhost:8080/mgmt/metrics
-* Prometheus: http://localhost:8080/mgmt/prom
+#### Metrikker (usikret):
+* Prometheus: http://localhost:8080/api/mgmt/prom

--- a/nais/nais-dev.yml
+++ b/nais/nais-dev.yml
@@ -32,6 +32,9 @@ spec:
       value: "http.proxy"
     - name: HTTP_PROXY
       value: http://webproxy-nais.nav.no:8088
+  prometheus:
+    enabled: true
+    path: /api/mgmt/prom
   vault:
     enabled: true
     paths:

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,19 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_hotspot</artifactId>
+            <version>0.9.0</version>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/SelvbetjeningOpptjeningApplication.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/SelvbetjeningOpptjeningApplication.java
@@ -1,5 +1,6 @@
 package no.nav.pensjon.selvbetjeningopptjening;
 
+import io.prometheus.client.hotspot.DefaultExports;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -7,7 +8,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class SelvbetjeningOpptjeningApplication {
 
     public static void main(String[] args) {
+        DefaultExports.initialize();
         SpringApplication.run(SelvbetjeningOpptjeningApplication.class, args);
     }
-
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,10 +6,12 @@ popp.endpoint.url=https://pensjon-popp-q2.nais.preprod.local/popp/api
 allowed.origins='*'
 debug=false
 
-#management.endpoints.web.base-path=/mgmt
-#management.endpoints.web.path-mapping.prometheus=prom
-#management.endpoints.web.exposure.include=*
-#management.endpoint.health.show-details=always
+management.endpoints.web.base-path=/api/mgmt
+management.endpoints.web.path-mapping.prometheus=prom
+management.endpoints.web.exposure.include=*
+management.endpoint.health.show-details=always
+management.endpoint.metrics.enabled=false
+management.endpoint.prometheus.enabled=true
 
 no.nav.security.jwt.issuer.selvbetjening.discovery-url=https://security-token-service.nais.preprod.local/.well-known/openid-configuration
 no.nav.security.jwt.issuer.selvbetjening.accepted_audience=srvpensjon


### PR DESCRIPTION
NAIS-plattformen har støtte for å vise Prometheus-formaterte metrikker i et Grafana-dashboard, se [Metrics](https://doc.nais.io/observability/metrics).
Denne PR gjør Spring Boots default-metrikker tilgjengelig (f.eks. JVM-minneforbruk).

Når denne PR er merget kan metrikkene ses på [https://pensjon-selvbetjening-opptjening-backend.nais.preprod.local/api/mgmt/prom](https://pensjon-selvbetjening-opptjening-backend.nais.preprod.local/api/mgmt/prom)

Litt bakgrunn om Prometheus: [Spring Boot Actuator metrics monitoring with Prometheus and Grafana](https://www.callicoder.com/spring-boot-actuator-metrics-monitoring-dashboard-prometheus-grafana/) 

