### PR TITLE
Feature/pl 3090

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,43 @@
 # pensjon-selvbetjening-opptjening-backend
 Applikasjon som samler inn rådata fra primært POPP 
 (register for pensjonsopptjening) og PEN (pensjonsfaglig kjerne) og orkestrerer disse dataene slik at de kan hentes
- og presenteres til bruker av applikasjonen pensjon-selvbetjening-opptjening-frontend. (https://github.com/navikt/pensjon-selvbetjening-opptjening-frontend)
+ og presenteres til bruker av applikasjonen [pensjon-selvbetjening-opptjening-frontend](https://github.com/navikt/pensjon-selvbetjening-opptjening-frontend).
 
 Applikasjonen er laget med utgangspunkt i logikk fra det gamle JSF-baserte skjermbildet "Din pensjonsopptjening" i PSELV som applikasjonen skal erstatte.
 
-## Henvendelser
-
-NAV-interne henvendelser kan sendes via Slack i kanalen [#po-pensjon-teamselvbetjening](https://nav-it.slack.com/archives/C014M7U1GBY).
-
 ## Dokumentasjon
-Dokumentasjon for applikasjonen er lagt sammen med koden og eksponeres på følgende url: https://pensjon-selvbetjening-opptjening-backend.nais.preprod.local
+
+Dokumentasjon for applikasjonen er lagt sammen med koden og eksponeres på følgende URL: https://pensjon-selvbetjening-opptjening-backend.nais.preprod.local
 (tilgjengelig i fagsystemsonen)
 
-## Utvikling lokalt
+## Kjøring av appen lokalt
 
-I et Java-IDE kjør `SelvbetjeningOpptjeningApplication`.
+I et Java-IDE kjør `LocalOpptjeningApplication`.
 
-Bruk profil `laptop` for test på mobilitetsløsning, eller `uimage` for Utviklerimage.
+Bruk Spring-profil `laptop` for kjøring på mobilitetsløsning, eller `uimage` på Utviklerimage.
 
-Eksempel VM options i Run/Debug config: `-Dspring.profiles.active=laptop -Dfnr=<fnr>`
+Angi fødselsnummeret/D-nummeret til personen man skal hente data for med VM-option `fnr`.
 
-På laptop bruk k8s port-forwarding for tjenestene STS, PEN og POPP.
+Eksempel VM-options i Run/Debug config: `-Dspring.profiles.active=laptop -Dfnr=01020312345`
+
+På laptop bruk Kubernetes port-forwarding for tjenestene PEN, POPP, PDL og STS (se [application-laptop.properties](https://github.com/navikt/pensjon-selvbetjening-opptjening-backend/blob/feature/PL-3090/src/main/resources/application-laptop.properties) for detaljer).
 
 ### Endepunkter
 
-#### Pensjonsrelaterte (sikrede):
+#### Pensjonsrelatert:
 * Opptjening: http://localhost:8080/api/opptjening/
 
-#### Applikasjonshelse (usikrede):
+NB: Denne krever et token for tilgang; det kan skaffes ved først å gjøre en "liksom-innlogging":
+* http://localhost:8080/api/mocklogin/
+
+#### Applikasjonshelse:
 * Liveness: http://localhost:8080/api/internal/isAlive
 * Readiness: http://localhost:8080/api/internal/isReady
 * Helse: http://localhost:8080/api/mgmt/health
 
-#### Metrikker (usikret):
+#### Applikasjonsmetrikker:
 * Prometheus: http://localhost:8080/api/mgmt/prom
+
+## Henvendelser
+
+NAV-interne henvendelser kan sendes via Slack i kanalen [#po-pensjon-teamselvbetjening](https://nav-it.slack.com/archives/C014M7U1GBY).

--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,12 @@
             <version>${okhttp3.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>no.nav.security</groupId>
+            <artifactId>mock-oauth2-server</artifactId>
+            <version>0.1.35</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/config/OpptjeningConfig.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/config/OpptjeningConfig.java
@@ -19,7 +19,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/config/OpptjeningConfig.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/config/OpptjeningConfig.java
@@ -83,15 +83,8 @@ public class OpptjeningConfig {
     }
 
     @Bean
-    @Profile("default")
     public LoginInfoGetter loginInfoGetter(TokenValidationContextHolder context) {
         return new TokenLoginInfoExtractor(context);
-    }
-
-    @Bean
-    @Profile("!default")
-    public LoginInfoGetter simpleLoginInfoGetter(@Value("${fnr}") String fnr) {
-        return new SimpleLoginInfoGetter(fnr);
     }
 
     private static MappingJackson2HttpMessageConverter createCustomMessageConverterForLocalDate() {

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningEndpoint.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningEndpoint.java
@@ -19,7 +19,7 @@ import static no.nav.pensjon.selvbetjeningopptjening.util.Constants.ISSUER;
 
 @RestController
 @RequestMapping("api")
-@ProtectedWithClaims(issuer = ISSUER) // Use @Unprotected when running with laptop/uimage profile
+@ProtectedWithClaims(issuer = ISSUER)
 public class OpptjeningEndpoint {
 
     private final Log log = LogFactory.getLog(getClass());

--- a/src/main/resources/application-laptop.properties
+++ b/src/main/resources/application-laptop.properties
@@ -4,6 +4,7 @@
 # kubectl -n default port-forward service/security-token-service --address 0.0.0.0 7000:80
 # kubectl -n teampensjon port-forward service/pensjon-pen-q2 --address 0.0.0.0 7001:80
 # kubectl -n teampensjon port-forward service/pensjon-popp-q2 --address 0.0.0.0 7002:80
+# kubectl -n default port-forward service/pdl-api --address 0.0.0.0 7003:80
 serviceusertoken.endpoint.url=http://localhost:7000/rest/v1/sts/token
 pen.endpoint.url=http://localhost:7001/pen/api/
 popp.endpoint.url=http://localhost:7002/popp/api
@@ -12,3 +13,9 @@ pdl.endpoint.url=http://localhost:7003/graphql
 internal-user.openid.redirect-uri=http://localhost:8080/oauth2/internal/callback
 external-user.openid.redirect-uri=http://localhost:8080/oauth2/external/callback
 cookies.insecure=true
+
+# discovery-url = http://localhost:<port>/<issuer>/.well-known/openid-configuration, where
+# <port> = LocalOpptjeningApplication.AUTH_SERVER_PORT, <issuer> = MockLoginEndpoint.ISSUER_ID
+no.nav.security.jwt.issuer.selvbetjening.discovery-url=http://localhost:8081/default/.well-known/openid-configuration
+no.nav.security.jwt.issuer.selvbetjening.accepted_audience=local-opptjening
+no.nav.security.jwt.issuer.selvbetjening.cookie_name=mock-idtoken

--- a/src/main/resources/application-uimage.properties
+++ b/src/main/resources/application-uimage.properties
@@ -7,3 +7,9 @@ cookies.insecure=true
 http.proxy.parametername=http.proxy
 # WebClient needs explicit proxy URI:
 http.proxy.uri=http://webproxy-utvikler.nav.no:8088
+
+# discovery-url = http://localhost:<port>/<issuer>/.well-known/openid-configuration, where
+# <port> = LocalOpptjeningApplication.AUTH_SERVER_PORT, <issuer> = MockLoginEndpoint.ISSUER_ID
+no.nav.security.jwt.issuer.selvbetjening.discovery-url=http://localhost:8081/default/.well-known/openid-configuration
+no.nav.security.jwt.issuer.selvbetjening.accepted_audience=local-opptjening
+no.nav.security.jwt.issuer.selvbetjening.cookie_name=mock-idtoken

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/LocalOpptjeningApplication.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/LocalOpptjeningApplication.java
@@ -1,0 +1,35 @@
+package no.nav.pensjon.selvbetjeningopptjening;
+
+import io.prometheus.client.hotspot.DefaultExports;
+import no.nav.security.mock.oauth2.MockOAuth2Server;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import java.io.IOException;
+
+@SpringBootApplication
+public class LocalOpptjeningApplication {
+
+    private static final int AUTH_SERVER_PORT = 8081;
+    private static MockOAuth2Server authServer;
+
+    public static void main(String[] args) {
+        DefaultExports.initialize();
+        startMockAuthServer();
+        SpringApplication.run(SelvbetjeningOpptjeningApplication.class, args);
+    }
+
+    public static MockOAuth2Server getAuthServer() {
+        return authServer;
+    }
+
+    private static void startMockAuthServer() {
+        authServer = new MockOAuth2Server();
+
+        try {
+            authServer.start(AUTH_SERVER_PORT);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/config/SimpleLoginInfoGetterTest.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/config/SimpleLoginInfoGetterTest.java
@@ -1,6 +1,7 @@
 package no.nav.pensjon.selvbetjeningopptjening.config;
 
 import no.nav.pensjon.selvbetjeningopptjening.TestFnrs;
+import no.nav.pensjon.selvbetjeningopptjening.mock.MockLoginInfoGetter;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -9,7 +10,7 @@ class SimpleLoginInfoGetterTest {
 
     @Test
     void getLoginInfo_shall_contain_supplied_fnr() {
-        String fnr = new SimpleLoginInfoGetter(TestFnrs.NORMAL).getLoginInfo().getPid().getPid();
+        String fnr = new MockLoginInfoGetter(TestFnrs.NORMAL).getLoginInfo().getPid().getPid();
         assertEquals(TestFnrs.NORMAL, fnr);
     }
 }

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/health/ReadinessEndpointTest.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/health/ReadinessEndpointTest.java
@@ -1,14 +1,17 @@
 package no.nav.pensjon.selvbetjeningopptjening.health;
 
+import no.nav.pensjon.selvbetjeningopptjening.SelvbetjeningOpptjeningApplication;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ReadinessEndpoint.class)
+@ContextConfiguration(classes = SelvbetjeningOpptjeningApplication.class)
 class ReadinessEndpointTest {
 
     @Autowired

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/mock/MockLoginEndpoint.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/mock/MockLoginEndpoint.java
@@ -1,0 +1,58 @@
+package no.nav.pensjon.selvbetjeningopptjening.mock;
+
+import com.nimbusds.jwt.SignedJWT;
+import no.nav.pensjon.selvbetjeningopptjening.LocalOpptjeningApplication;
+import no.nav.security.mock.oauth2.MockOAuth2Server;
+import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback;
+import no.nav.security.token.support.core.api.Unprotected;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("api")
+@Unprotected
+public class MockLoginEndpoint {
+
+    private static final String AUDIENCE = "local-opptjening";
+    private static final String COOKIE_NAME = "mock-idtoken";
+    private static final String ISSUER_ID = "default";
+    private static final long EXPIRY = 1000000L; // approx. 12 days in seconds
+    private final String fnr;
+
+    public MockLoginEndpoint(@Value("${fnr}") String fnr) {
+        this.fnr = fnr;
+    }
+
+    @GetMapping("/mocklogin")
+    public void login(HttpServletResponse response) {
+        response.addCookie(authCookie());
+    }
+
+    private Cookie authCookie() {
+        var cookie = new Cookie(COOKIE_NAME, initializeAuth().serialize());
+        cookie.setPath("/");
+        cookie.setSecure(false);
+        cookie.setHttpOnly(false);
+        return cookie;
+    }
+
+    private SignedJWT initializeAuth() {
+        var callback = new DefaultOAuth2TokenCallback(ISSUER_ID, fnr, AUDIENCE, claims(), EXPIRY);
+        MockOAuth2Server authServer = LocalOpptjeningApplication.getAuthServer();
+        authServer.enqueueCallback(callback);
+        return authServer.issueToken(ISSUER_ID, "dummy", callback);
+    }
+
+    private static Map<String, String> claims() {
+        Map<String, String> claims = new HashMap<>();
+        claims.put("acr", "Level4");
+        return claims;
+    }
+}

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/mock/MockLoginInfoGetter.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/mock/MockLoginInfoGetter.java
@@ -1,15 +1,15 @@
-package no.nav.pensjon.selvbetjeningopptjening.config;
+package no.nav.pensjon.selvbetjeningopptjening.mock;
 
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.Pid;
 import no.nav.pensjon.selvbetjeningopptjening.security.LoginSecurityLevel;
 import no.nav.pensjon.selvbetjeningopptjening.usersession.LoginInfo;
 import no.nav.pensjon.selvbetjeningopptjening.usersession.LoginInfoGetter;
 
-public class SimpleLoginInfoGetter implements LoginInfoGetter {
+public class MockLoginInfoGetter implements LoginInfoGetter {
 
     private final String fnr;
 
-    public SimpleLoginInfoGetter(String fnr) {
+    public MockLoginInfoGetter(String fnr) {
         this.fnr = fnr;
     }
 

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningEndpointTest.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningEndpointTest.java
@@ -2,6 +2,7 @@ package no.nav.pensjon.selvbetjeningopptjening.opptjening;
 
 import no.finn.unleash.FakeUnleash;
 import no.nav.pensjon.selvbetjeningopptjening.PidGenerator;
+import no.nav.pensjon.selvbetjeningopptjening.SelvbetjeningOpptjeningApplication;
 import no.nav.pensjon.selvbetjeningopptjening.config.OpptjeningFeature;
 import no.nav.pensjon.selvbetjeningopptjening.consumer.FailedCallingExternalServiceException;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.dto.OpptjeningResponse;
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.web.server.ResponseStatusException;
@@ -29,6 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(OpptjeningEndpoint.class)
+@ContextConfiguration(classes = SelvbetjeningOpptjeningApplication.class)
 class OpptjeningEndpointTest {
 
     private static final String URI = "/api/opptjening";

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningOnBehalfEndpointTest.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningOnBehalfEndpointTest.java
@@ -2,6 +2,7 @@ package no.nav.pensjon.selvbetjeningopptjening.opptjening;
 
 import no.finn.unleash.FakeUnleash;
 import no.nav.pensjon.selvbetjeningopptjening.PidGenerator;
+import no.nav.pensjon.selvbetjeningopptjening.SelvbetjeningOpptjeningApplication;
 import no.nav.pensjon.selvbetjeningopptjening.config.OpptjeningFeature;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.dto.OpptjeningDto;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.dto.OpptjeningResponse;
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 
 import javax.servlet.http.Cookie;
@@ -25,6 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(OpptjeningOnBehalfEndpoint.class)
+@ContextConfiguration(classes = SelvbetjeningOpptjeningApplication.class)
 class OpptjeningOnBehalfEndpointTest {
 
     private static final Pid PID = PidGenerator.generatePidAtAge(65);

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/unleash/UnleashStatusEndpointTest.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/unleash/UnleashStatusEndpointTest.java
@@ -3,19 +3,22 @@ package no.nav.pensjon.selvbetjeningopptjening.unleash;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import no.finn.unleash.FakeUnleash;
+import no.nav.pensjon.selvbetjeningopptjening.SelvbetjeningOpptjeningApplication;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
+
 import java.util.Collections;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-
 @WebMvcTest(UnleashStatusEndpoint.class)
+@ContextConfiguration(classes = SelvbetjeningOpptjeningApplication.class)
 class UnleashStatusEndpointTest {
 
     private static final String URI = "/api/unleash";
@@ -32,7 +35,6 @@ class UnleashStatusEndpointTest {
 
     @Test
     void getUnleashStatus_returns_Status_OK_when_valid_input() throws Exception {
-
         mvc.perform(post(URI)
                 .contentType("application/json")
                 .content(UnleashStatusEndpointTest.request()))
@@ -41,7 +43,6 @@ class UnleashStatusEndpointTest {
 
     @Test
     void getUnleashStatus_returns_UnleashStatusResponseJson_when_requestBody_has_toggleList() throws Exception {
-
         mvc.perform(post(URI)
                 .contentType("application/json")
                 .content(UnleashStatusEndpointTest.request()))
@@ -69,11 +70,11 @@ class UnleashStatusEndpointTest {
                 .andExpect(content().json("{}"));
     }
 
-    private  static String request() {
-        UnleashStatusRequest request = new UnleashStatusRequest();
+    private static String request() {
+        var request = new UnleashStatusRequest();
         request.setToggleList(Collections.singletonList("toggle1"));
+        var mapper = new ObjectMapper();
 
-        ObjectMapper mapper = new ObjectMapper();
         try {
             return mapper.writeValueAsString(request);
         } catch (JsonProcessingException e) {

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/unleash/strategies/ByProfileStrategyTest.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/unleash/strategies/ByProfileStrategyTest.java
@@ -1,7 +1,7 @@
 package no.nav.pensjon.selvbetjeningopptjening.unleash.strategies;
 
-import no.nav.pensjon.selvbetjeningopptjening.config.SimpleLoginInfoGetter;
 import no.nav.pensjon.selvbetjeningopptjening.consumer.uttaksgrad.UttaksgradGetter;
+import no.nav.pensjon.selvbetjeningopptjening.mock.MockLoginInfoGetter;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.Uttaksgrad;
 import no.nav.pensjon.selvbetjeningopptjening.usersession.LoginInfoGetter;
 import org.junit.jupiter.api.BeforeEach;
@@ -96,7 +96,7 @@ class ByProfileStrategyTest {
         @Override
         @SuppressWarnings("unchecked")
         protected <T> T getBean(Class<T> beanClass) {
-            return beanClass == LoginInfoGetter.class ? (T) new SimpleLoginInfoGetter(fnr) : (T) uttaksgradGetter;
+            return beanClass == LoginInfoGetter.class ? (T) new MockLoginInfoGetter(fnr) : (T) uttaksgradGetter;
         }
 
         void setFnrBefore1962() {

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/unleash/strategies/ByUserIdStrategyTest.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/unleash/strategies/ByUserIdStrategyTest.java
@@ -1,7 +1,7 @@
 package no.nav.pensjon.selvbetjeningopptjening.unleash.strategies;
 
 import no.nav.pensjon.selvbetjeningopptjening.TestFnrs;
-import no.nav.pensjon.selvbetjeningopptjening.config.SimpleLoginInfoGetter;
+import no.nav.pensjon.selvbetjeningopptjening.mock.MockLoginInfoGetter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -70,7 +70,7 @@ class ByUserIdStrategyTest {
         @Override
         @SuppressWarnings("unchecked")
         protected <T> T getBean(Class<T> beanClass) {
-            return (T) new SimpleLoginInfoGetter(userId);
+            return (T) new MockLoginInfoGetter(userId);
         }
 
         void seMismatchingUserId() {

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/usersession/internaluser/InternalUserAuthorizationCodeFlowTest.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/usersession/internaluser/InternalUserAuthorizationCodeFlowTest.java
@@ -1,6 +1,7 @@
 package no.nav.pensjon.selvbetjeningopptjening.usersession.internaluser;
 
 import io.jsonwebtoken.JwtException;
+import no.nav.pensjon.selvbetjeningopptjening.SelvbetjeningOpptjeningApplication;
 import no.nav.pensjon.selvbetjeningopptjening.security.crypto.Crypto;
 import no.nav.pensjon.selvbetjeningopptjening.security.http.CookieSetter;
 import no.nav.pensjon.selvbetjeningopptjening.security.http.CookieType;
@@ -15,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
@@ -32,6 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(InternalUserAuthorizationCodeFlow.class)
+@ContextConfiguration(classes = SelvbetjeningOpptjeningApplication.class)
 class InternalUserAuthorizationCodeFlowTest {
 
     private static final String ROOT_URL = "/oauth2/internal";


### PR DESCRIPTION
Bruk av [mock-oauth2-server](https://github.com/navikt/mock-oauth2-server) for å kunne gjøre en liksom-innlogging for å få tak i et token. Man slipper dermed å måtte gjøre `OpptjeningEndpoint` `@Unprotected` for å kunne gjøre kall mot lokalt kjørende Opptjening-backend (eller på innfløkt måte skaffe et virkelig token).

For å skaffe et token holder det å gjøre en `GET http://localhost:8080/api/mocklogin/`