### PR TITLE
PL-2908 Make selftest report status of services

### DIFF
--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/auth/serviceusertoken/OidcAuthTokenInterceptor.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/auth/serviceusertoken/OidcAuthTokenInterceptor.java
@@ -1,32 +1,44 @@
 package no.nav.pensjon.selvbetjeningopptjening.auth.serviceusertoken;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
 
+import java.io.IOException;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
 public class OidcAuthTokenInterceptor implements ClientHttpRequestInterceptor {
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
-    private final ServiceUserTokenGetter serviceUserTokenGetter;
+    private static final String AUTH_TYPE = "Bearer";
+    private final Log log = LogFactory.getLog(getClass());
+    private final ServiceUserTokenGetter tokenGetter;
 
-    public OidcAuthTokenInterceptor(ServiceUserTokenGetter serviceUserTokenGetter) {
-        this.serviceUserTokenGetter = serviceUserTokenGetter;
+    public OidcAuthTokenInterceptor(ServiceUserTokenGetter tokenGetter) {
+        this.tokenGetter = requireNonNull(tokenGetter);
     }
 
     @Override
-    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) {
-        logger.debug("Adding OIDC Authorization header to {} {}", request.getMethod(), request.getURI());
+    public ClientHttpResponse intercept(HttpRequest request,
+                                        byte[] body,
+                                        ClientHttpRequestExecution requestExecution) throws IOException {
+        log.debug(format("Adding OIDC authorization header to %s %s", request.getMethod(), request.getURI()));
 
         try {
-            request.getHeaders().add(HttpHeaders.AUTHORIZATION, "Bearer " + serviceUserTokenGetter.getServiceUserToken().getAccessToken());
-            return execution.execute(request, body);
-        } catch (Exception e) {
-            logger.error("Error when trying to get OIDC token: " + e.getMessage(), e);
-            return null;
+            request.getHeaders().add(HttpHeaders.AUTHORIZATION, getAuth());
+        } catch (StsException e) {
+            throw new IOException("STS access error", e);
         }
+
+        return requestExecution.execute(request, body);
+    }
+
+    private String getAuth() throws StsException {
+        return AUTH_TYPE + " " + tokenGetter.getServiceUserToken().getAccessToken();
     }
 }

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/auth/serviceusertoken/ServiceUserTokenGetter.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/auth/serviceusertoken/ServiceUserTokenGetter.java
@@ -2,5 +2,5 @@ package no.nav.pensjon.selvbetjeningopptjening.auth.serviceusertoken;
 
 public interface ServiceUserTokenGetter {
 
-    ServiceUserToken getServiceUserToken();
+    ServiceUserToken getServiceUserToken() throws StsException;
 }

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/auth/serviceusertoken/StsException.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/auth/serviceusertoken/StsException.java
@@ -1,0 +1,11 @@
+package no.nav.pensjon.selvbetjeningopptjening.auth.serviceusertoken;
+
+/**
+ * Used for problems related to Security Token Service (STS) access.
+ */
+public class StsException extends Exception {
+
+    StsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/consumer/FailedCallingExternalServiceException.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/consumer/FailedCallingExternalServiceException.java
@@ -2,11 +2,18 @@ package no.nav.pensjon.selvbetjeningopptjening.consumer;
 
 public class FailedCallingExternalServiceException extends RuntimeException {
 
-    public FailedCallingExternalServiceException(String serviceProvider, String serviceIdentifier, String detailMessage, Throwable cause) {
+    public FailedCallingExternalServiceException(String serviceProvider,
+                                                 String serviceIdentifier,
+                                                 String detailMessage,
+                                                 Throwable cause) {
         super("Error when calling the external service " + serviceIdentifier + " in " + serviceProvider + ". " + detailMessage, cause);
     }
 
     public FailedCallingExternalServiceException(String serviceProvider, String detailMessage) {
         super("Error when calling the external service " + serviceProvider + ". " + detailMessage);
+    }
+
+    public FailedCallingExternalServiceException(String serviceProvider, Throwable cause) {
+        super("Error when calling the external service " + serviceProvider, cause);
     }
 }

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/consumer/PoppUtil.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/consumer/PoppUtil.java
@@ -1,6 +1,7 @@
 package no.nav.pensjon.selvbetjeningopptjening.consumer;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestClientResponseException;
 
 import static no.nav.pensjon.selvbetjeningopptjening.util.Constants.POPP;
@@ -25,6 +26,10 @@ public class PoppUtil {
         }
 
         return new FailedCallingExternalServiceException(POPP, service, "An error occurred in the provider", e);
+    }
+
+    public static FailedCallingExternalServiceException handle(RestClientException e, String service) {
+        return new FailedCallingExternalServiceException(POPP, service, "Failed to access service", e);
     }
 
     private static boolean isPersonDoesNotExistMessage(String exceptionMessage) {

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/consumer/opptjeningsgrunnlag/OpptjeningsgrunnlagConsumer.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/consumer/opptjeningsgrunnlag/OpptjeningsgrunnlagConsumer.java
@@ -2,11 +2,11 @@ package no.nav.pensjon.selvbetjeningopptjening.consumer.opptjeningsgrunnlag;
 
 import no.nav.pensjon.selvbetjeningopptjening.health.PingInfo;
 import no.nav.pensjon.selvbetjeningopptjening.health.Pingable;
-import no.nav.pensjon.selvbetjeningopptjening.consumer.FailedCallingExternalServiceException;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.Inntekt;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpMethod;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -15,7 +15,6 @@ import java.util.List;
 
 import static no.nav.pensjon.selvbetjeningopptjening.consumer.PoppUtil.handle;
 import static no.nav.pensjon.selvbetjeningopptjening.opptjening.mapping.InntektMapper.fromDto;
-import static no.nav.pensjon.selvbetjeningopptjening.util.Constants.POPP;
 
 public class OpptjeningsgrunnlagConsumer implements Pingable {
 
@@ -41,8 +40,8 @@ public class OpptjeningsgrunnlagConsumer implements Pingable {
             return response == null ? null : fromDto(response.getOpptjeningsGrunnlag().getInntektListe());
         } catch (RestClientResponseException e) {
             throw handle(e, CONSUMED_SERVICE);
-        } catch (Exception e) {
-            throw new FailedCallingExternalServiceException(POPP, CONSUMED_SERVICE, "An error occurred in the consumer", e);
+        } catch (RestClientException e) {
+            throw handle(e, CONSUMED_SERVICE);
         }
     }
 
@@ -78,12 +77,13 @@ public class OpptjeningsgrunnlagConsumer implements Pingable {
                     String.class).getBody();
         } catch (RestClientResponseException e) {
             throw handle(e, CONSUMED_SERVICE);
+        } catch (RestClientException e) {
+            throw handle(e, CONSUMED_SERVICE);
         }
     }
 
     @Override
     public PingInfo getPingInfo() {
-        return new PingInfo("REST", "POPP Pensjon Beholdning", UriComponentsBuilder.fromHttpUrl(endpoint).path("/opptjeningsgrunnlag/ping").toUriString());
+        return new PingInfo("REST", "POPP opptjeningsgrunnlag", UriComponentsBuilder.fromHttpUrl(endpoint).path("/opptjeningsgrunnlag/ping").toUriString());
     }
-
 }

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/consumer/pensjonsbeholdning/PensjonsbeholdningConsumer.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/consumer/pensjonsbeholdning/PensjonsbeholdningConsumer.java
@@ -2,11 +2,11 @@ package no.nav.pensjon.selvbetjeningopptjening.consumer.pensjonsbeholdning;
 
 import no.nav.pensjon.selvbetjeningopptjening.health.PingInfo;
 import no.nav.pensjon.selvbetjeningopptjening.health.Pingable;
-import no.nav.pensjon.selvbetjeningopptjening.consumer.FailedCallingExternalServiceException;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.Beholdning;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -15,13 +15,13 @@ import java.util.List;
 
 import static no.nav.pensjon.selvbetjeningopptjening.consumer.PoppUtil.handle;
 import static no.nav.pensjon.selvbetjeningopptjening.opptjening.mapping.BeholdningMapper.fromDto;
-import static no.nav.pensjon.selvbetjeningopptjening.util.Constants.POPP;
 
 public class PensjonsbeholdningConsumer implements Pingable {
 
     static final String CONSUMED_SERVICE = "PROPOPP006 hentPensjonsbeholdningListe";
     private final String endpoint;
     private RestTemplate restTemplate;
+    //TODO use WebClient
 
     public PensjonsbeholdningConsumer(String endpoint, RestTemplate restTemplate) {
         this.endpoint = endpoint;
@@ -40,8 +40,8 @@ public class PensjonsbeholdningConsumer implements Pingable {
             return response == null ? null : fromDto(response.getBeholdninger());
         } catch (RestClientResponseException e) {
             throw handle(e, CONSUMED_SERVICE);
-        } catch (Exception e) {
-            throw new FailedCallingExternalServiceException(POPP, CONSUMED_SERVICE, "An error occurred in the consumer", e);
+        } catch (RestClientException e) {
+            throw handle(e, CONSUMED_SERVICE);
         }
     }
 
@@ -68,11 +68,13 @@ public class PensjonsbeholdningConsumer implements Pingable {
                     String.class).getBody();
         } catch (RestClientResponseException e) {
             throw handle(e, CONSUMED_SERVICE);
+        } catch (RestClientException e) {
+            throw handle(e, CONSUMED_SERVICE);
         }
     }
 
     @Override
     public PingInfo getPingInfo() {
-        return new PingInfo("REST", "POPP Pensjon Beholdning", buildUrl());
+        return new PingInfo("REST", "POPP pensjonsbeholdning", buildUrl());
     }
 }

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/consumer/pensjonspoeng/PensjonspoengConsumer.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/consumer/pensjonspoeng/PensjonspoengConsumer.java
@@ -2,12 +2,12 @@ package no.nav.pensjon.selvbetjeningopptjening.consumer.pensjonspoeng;
 
 import no.nav.pensjon.selvbetjeningopptjening.health.PingInfo;
 import no.nav.pensjon.selvbetjeningopptjening.health.Pingable;
-import no.nav.pensjon.selvbetjeningopptjening.consumer.FailedCallingExternalServiceException;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.Pensjonspoeng;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.PensjonspoengMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpMethod;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -15,13 +15,13 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.util.List;
 
 import static no.nav.pensjon.selvbetjeningopptjening.consumer.PoppUtil.handle;
-import static no.nav.pensjon.selvbetjeningopptjening.util.Constants.POPP;
 
 public class PensjonspoengConsumer implements Pingable {
 
     static final String CONSUMED_SERVICE = "PROPOPP019 hentPensjonspoengListe";
     private final String endpoint;
     private RestTemplate restTemplate;
+    //TODO use WebClient
 
     public PensjonspoengConsumer(String endpoint) {
         this.endpoint = endpoint;
@@ -39,8 +39,8 @@ public class PensjonspoengConsumer implements Pingable {
             return response == null ? null : PensjonspoengMapper.fromDto(response.getPensjonspoeng());
         } catch (RestClientResponseException e) {
             throw handle(e, CONSUMED_SERVICE);
-        } catch (Exception e) {
-            throw new FailedCallingExternalServiceException(POPP, CONSUMED_SERVICE, "An error occurred in the consumer", e);
+        } catch (RestClientException e) {
+            throw handle(e, CONSUMED_SERVICE);
         }
     }
 
@@ -54,12 +54,14 @@ public class PensjonspoengConsumer implements Pingable {
                     String.class).getBody();
         } catch (RestClientResponseException e) {
             throw handle(e, CONSUMED_SERVICE);
+        } catch (RestClientException e) {
+            throw handle(e, CONSUMED_SERVICE);
         }
     }
 
     @Override
     public PingInfo getPingInfo() {
-        return new PingInfo("REST", "POPP PensjonPoeng", UriComponentsBuilder.fromHttpUrl(endpoint).path("/pensjonspoeng/ping").toUriString());
+        return new PingInfo("REST", "POPP pensjonspoeng", UriComponentsBuilder.fromHttpUrl(endpoint).path("/pensjonspoeng/ping").toUriString());
     }
 
     private String buildUrl(String fnr) {

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/consumer/person/PersonConsumer.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/consumer/person/PersonConsumer.java
@@ -26,7 +26,7 @@ public class PersonConsumer implements Pingable {
 
     private static final String AFP_HISTORIKK_SERVICE = "PROPEN2602 getAfphistorikkForPerson";
     private static final String UFORE_HISTORIKK_SERVICE = "PROPEN2603 getUforehistorikkForPerson";
-    private static final String PING_SERVICE = "ping";
+    private static final String PING_SERVICE = "PEN person ping";
     private String endpoint;
     private RestTemplate restTemplate;
     //TODO Migrate to WebClient

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/consumer/restpensjon/RestpensjonConsumer.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/consumer/restpensjon/RestpensjonConsumer.java
@@ -2,11 +2,11 @@ package no.nav.pensjon.selvbetjeningopptjening.consumer.restpensjon;
 
 import no.nav.pensjon.selvbetjeningopptjening.health.PingInfo;
 import no.nav.pensjon.selvbetjeningopptjening.health.Pingable;
-import no.nav.pensjon.selvbetjeningopptjening.consumer.FailedCallingExternalServiceException;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.Restpensjon;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpMethod;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -15,13 +15,13 @@ import java.util.List;
 
 import static no.nav.pensjon.selvbetjeningopptjening.consumer.PoppUtil.handle;
 import static no.nav.pensjon.selvbetjeningopptjening.opptjening.mapping.RestpensjonMapper.fromDto;
-import static no.nav.pensjon.selvbetjeningopptjening.util.Constants.POPP;
 
 public class RestpensjonConsumer implements Pingable {
 
     private static final String CONSUMED_SERVICE = "PROPOPP013 hentRestpensjoner";
     private final String endpoint;
     private RestTemplate restTemplate;
+    //TODO use WebClient
 
     public RestpensjonConsumer(String endpoint) {
         this.endpoint = endpoint;
@@ -39,8 +39,8 @@ public class RestpensjonConsumer implements Pingable {
             return response == null ? null : fromDto(response.getRestpensjoner());
         } catch (RestClientResponseException e) {
             throw handle(e, CONSUMED_SERVICE);
-        } catch (Exception e) {
-            throw new FailedCallingExternalServiceException(POPP, CONSUMED_SERVICE, "An error occurred in the consumer", e);
+        } catch (RestClientException e) {
+            throw handle(e, CONSUMED_SERVICE);
         }
     }
 
@@ -54,12 +54,14 @@ public class RestpensjonConsumer implements Pingable {
                     String.class).getBody();
         } catch (RestClientResponseException e) {
             throw handle(e, CONSUMED_SERVICE);
+        } catch (RestClientException e) {
+            throw handle(e, CONSUMED_SERVICE);
         }
     }
 
     @Override
     public PingInfo getPingInfo() {
-        return new PingInfo("REST", "POPP Restpensjon", UriComponentsBuilder.fromHttpUrl(endpoint).path("/restpensjon/ping").toUriString());
+        return new PingInfo("REST", "POPP restpensjon", UriComponentsBuilder.fromHttpUrl(endpoint).path("/restpensjon/ping").toUriString());
     }
 
     private String buildUrl(String fnr) {

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/consumer/uttaksgrad/UttaksgradConsumer.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/consumer/uttaksgrad/UttaksgradConsumer.java
@@ -27,7 +27,7 @@ public class UttaksgradConsumer implements UttaksgradGetter, Pingable {
 
     private static final String UTTAKSGRAD_SERVICE = "PROPEN3000 getUttaksgradForVedtak";
     private static final String UTTAKSGRAD_HISTORIKK_SERVICE = "PROPEN3001 getAlderSakUttaksgradhistorikkForPerson";
-    private static final String PING_SERVICE = "ping";
+    private static final String PING_SERVICE = "PEN uttaksgrad ping";
     private final String endpoint;
     private RestTemplate restTemplate;
     //TODO use WebClient

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/consumer/uttaksgrad/UttaksgradConsumer.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/consumer/uttaksgrad/UttaksgradConsumer.java
@@ -2,6 +2,7 @@ package no.nav.pensjon.selvbetjeningopptjening.consumer.uttaksgrad;
 
 import no.nav.pensjon.selvbetjeningopptjening.health.PingInfo;
 import no.nav.pensjon.selvbetjeningopptjening.consumer.FailedCallingExternalServiceException;
+import no.nav.pensjon.selvbetjeningopptjening.health.Pingable;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.Uttaksgrad;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.mapping.UttaksgradMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,6 +13,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -21,10 +23,14 @@ import java.util.List;
 import static no.nav.pensjon.selvbetjeningopptjening.util.Constants.PEN;
 
 @Component
-public class UttaksgradConsumer implements UttaksgradGetter {
+public class UttaksgradConsumer implements UttaksgradGetter, Pingable {
 
+    private static final String UTTAKSGRAD_SERVICE = "PROPEN3000 getUttaksgradForVedtak";
+    private static final String UTTAKSGRAD_HISTORIKK_SERVICE = "PROPEN3001 getAlderSakUttaksgradhistorikkForPerson";
+    private static final String PING_SERVICE = "ping";
     private final String endpoint;
     private RestTemplate restTemplate;
+    //TODO use WebClient
 
     public UttaksgradConsumer(@Value("${pen.endpoint.url}") String endpoint) {
         this.endpoint = endpoint;
@@ -42,18 +48,13 @@ public class UttaksgradConsumer implements UttaksgradGetter {
 
             return response == null ? null : UttaksgradMapper.fromDtos(response.getUttaksgradList());
         } catch (RestClientResponseException e) {
-            throw handle(e, "PROPEN3000 getUttaksgradForVedtak");
-        } catch (Exception e) {
-            throw new FailedCallingExternalServiceException(PEN, "PROPEN3000 getUttaksgradForVedtak", "An error occurred in the consumer", e);
+            throw handle(e, UTTAKSGRAD_SERVICE);
+        } catch (RestClientException e) {
+            throw handle(e, UTTAKSGRAD_SERVICE);
         }
     }
 
-    private String buildUrl(String endpoint, List<Long> vedtakIds) {
-        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(endpoint).path("/uttaksgrad/search");
-        vedtakIds.forEach(vedtakId -> uriBuilder.queryParam("vedtakId", vedtakId));
-        return uriBuilder.toUriString();
-    }
-
+    @Override
     public List<Uttaksgrad> getAlderSakUttaksgradhistorikkForPerson(String fnr) {
         try {
             UttaksgradListResponse response = restTemplate.exchange(
@@ -65,9 +66,9 @@ public class UttaksgradConsumer implements UttaksgradGetter {
 
             return response == null ? null : UttaksgradMapper.fromDtos(response.getUttaksgradList());
         } catch (RestClientResponseException e) {
-            throw handle(e, "PROPEN3001 getAlderSakUttaksgradhistorikkForPerson");
-        } catch (Exception e) {
-            throw new FailedCallingExternalServiceException(PEN, "PROPEN3001 getAlderSakUttaksgradhistorikkForPerson", "An error occurred in the consumer", e);
+            throw handle(e, UTTAKSGRAD_HISTORIKK_SERVICE);
+        } catch (RestClientException e) {
+            throw handle(e, UTTAKSGRAD_HISTORIKK_SERVICE);
         }
     }
 
@@ -80,13 +81,21 @@ public class UttaksgradConsumer implements UttaksgradGetter {
                     null,
                     String.class).getBody();
         } catch (RestClientResponseException e) {
-            throw handle(e, "Error in PEN Uttaksgrad");
+            throw handle(e, PING_SERVICE);
+        } catch (RestClientException e) {
+            throw handle(e, PING_SERVICE);
         }
     }
 
     @Override
     public PingInfo getPingInfo() {
-        return new PingInfo("REST", "PEN", UriComponentsBuilder.fromHttpUrl(endpoint).path("/uttaksgrad/ping").toUriString());
+        return new PingInfo("REST", "PEN uttaksgrad", UriComponentsBuilder.fromHttpUrl(endpoint).path("/uttaksgrad/ping").toUriString());
+    }
+
+    private String buildUrl(String endpoint, List<Long> vedtakIds) {
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(endpoint).path("/uttaksgrad/search");
+        vedtakIds.forEach(vedtakId -> uriBuilder.queryParam("vedtakId", vedtakId));
+        return uriBuilder.toUriString();
     }
 
     private FailedCallingExternalServiceException handle(RestClientResponseException e, String serviceIdentifier) {
@@ -103,6 +112,10 @@ public class UttaksgradConsumer implements UttaksgradGetter {
         }
 
         return new FailedCallingExternalServiceException(PEN, serviceIdentifier, "An error occurred in the consumer", e);
+    }
+
+    private static FailedCallingExternalServiceException handle(RestClientException e, String service) {
+        return new FailedCallingExternalServiceException(PEN, service, "Failed to access service", e);
     }
 
     @Autowired

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/consumer/uttaksgrad/UttaksgradGetter.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/consumer/uttaksgrad/UttaksgradGetter.java
@@ -1,11 +1,10 @@
 package no.nav.pensjon.selvbetjeningopptjening.consumer.uttaksgrad;
 
-import no.nav.pensjon.selvbetjeningopptjening.health.Pingable;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.Uttaksgrad;
 
 import java.util.List;
 
-public interface UttaksgradGetter extends Pingable {
+public interface UttaksgradGetter {
 
     List<Uttaksgrad> getUttaksgradForVedtak(List<Long> vedtakIdList);
 

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/health/ReadinessEndpoint.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/health/ReadinessEndpoint.java
@@ -1,24 +1,24 @@
 package no.nav.pensjon.selvbetjeningopptjening.health;
 
-import no.nav.pensjon.selvbetjeningopptjening.opptjening.OpptjeningProvider;
+import no.nav.security.token.support.core.api.Unprotected;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
-
-import no.nav.security.token.support.core.api.Unprotected;
-
-import java.util.Optional;
 
 @RestController
 @RequestMapping("api/internal")
 @Unprotected
 public class ReadinessEndpoint {
-    private OpptjeningProvider opptjeningProvider;
 
-    public ReadinessEndpoint(OpptjeningProvider opptjeningProvider) {
-        this.opptjeningProvider = opptjeningProvider;
+    private final Selftest selftest;
+
+    public ReadinessEndpoint(Selftest selftest) {
+        this.selftest = selftest;
     }
 
     @RequestMapping(path = "isAlive", method = RequestMethod.GET)
@@ -32,7 +32,13 @@ public class ReadinessEndpoint {
     }
 
     @RequestMapping(path = "selftest", method = RequestMethod.GET)
-    public void ping() {
-         opptjeningProvider.ping();
+    public ResponseEntity selftest() {
+        return new ResponseEntity<>(selftest.perform(), jsonContentType(), HttpStatus.OK);
+    }
+
+    private static MultiValueMap<String, String> jsonContentType() {
+        MultiValueMap<String, String> headers = new HttpHeaders();
+        headers.add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+        return headers;
     }
 }

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/health/Selftest.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/health/Selftest.java
@@ -1,0 +1,67 @@
+package no.nav.pensjon.selvbetjeningopptjening.health;
+
+import no.nav.pensjon.selvbetjeningopptjening.consumer.FailedCallingExternalServiceException;
+import no.nav.pensjon.selvbetjeningopptjening.consumer.opptjeningsgrunnlag.OpptjeningsgrunnlagConsumer;
+import no.nav.pensjon.selvbetjeningopptjening.consumer.pdl.PdlConsumer;
+import no.nav.pensjon.selvbetjeningopptjening.consumer.pensjonsbeholdning.PensjonsbeholdningConsumer;
+import no.nav.pensjon.selvbetjeningopptjening.consumer.pensjonspoeng.PensjonspoengConsumer;
+import no.nav.pensjon.selvbetjeningopptjening.consumer.person.PersonConsumer;
+import no.nav.pensjon.selvbetjeningopptjening.consumer.restpensjon.RestpensjonConsumer;
+import no.nav.pensjon.selvbetjeningopptjening.consumer.uttaksgrad.UttaksgradConsumer;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.joining;
+
+@Component
+public class Selftest {
+
+    private final List<Pingable> services;
+
+    public Selftest(OpptjeningsgrunnlagConsumer opptjeningsgrunnlagConsumer,
+                    PensjonsbeholdningConsumer pensjonsbeholdningConsumer,
+                    PensjonspoengConsumer pensjonspoengConsumer,
+                    RestpensjonConsumer restpensjonConsumer,
+                    PersonConsumer personConsumer,
+                    UttaksgradConsumer uttaksgradConsumer,
+                    PdlConsumer pdlConsumer) {
+        this.services = List.of(
+                opptjeningsgrunnlagConsumer,
+                pensjonsbeholdningConsumer,
+                pensjonspoengConsumer,
+                restpensjonConsumer,
+                personConsumer,
+                uttaksgradConsumer,
+                pdlConsumer);
+    }
+
+    /**
+     * Returns result of selftest in JSON format.
+     */
+    String perform() {
+        return format("[%s]", getServiceStatuses());
+    }
+
+    private String getServiceStatuses() {
+        return services
+                .stream()
+                .map(this::getStatus)
+                .collect(joining(","));
+    }
+
+    private String getStatus(Pingable service) {
+        return format("{\"service\":\"%s\",\"status\":\"%s\"}",
+                service.getPingInfo().getDescription(), ping(service));
+    }
+
+    private String ping(Pingable service) {
+        try {
+            service.ping();
+            return "up";
+        } catch (FailedCallingExternalServiceException e) {
+            return "down";
+        }
+    }
+}

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningProvider.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningProvider.java
@@ -71,16 +71,6 @@ public class OpptjeningProvider {
                         uttaksgradGetter));
     }
 
-    public void ping(){
-        pensjonsbeholdningConsumer.ping();
-        opptjeningsgrunnlagConsumer.ping();
-        personConsumer.ping();
-        pensjonspoengConsumer.ping() ;
-        restpensjonConsumer.ping();
-        uttaksgradGetter.ping();
-        personService.ping();
-    }
-
     private boolean shouldGetRestpensjon(UserGroup userGroup, List<Uttaksgrad> uttaksgrader) {
         return userGroup.hasRestpensjon() && userHasUttakAlderspensjonWithUttaksgradLessThan100(uttaksgrader);
     }

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/person/PersonService.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/person/PersonService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.util.List;
 
+import static java.util.Objects.requireNonNull;
 import static no.nav.pensjon.selvbetjeningopptjening.security.masking.Masker.maskFnr;
 
 @Service
@@ -21,11 +22,7 @@ public class PersonService {
     private final PdlConsumer pdlConsumer;
 
     public PersonService(PdlConsumer pdlConsumer) {
-        this.pdlConsumer = pdlConsumer;
-    }
-
-    public void ping(){
-        pdlConsumer.ping();
+        this.pdlConsumer = requireNonNull(pdlConsumer);
     }
 
     public LocalDate getBirthDate(Pid pid, LoginSecurityLevel securityLevel) {

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/auth/serviceusertoken/OidcAuthTokenInterceptorTest.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/auth/serviceusertoken/OidcAuthTokenInterceptorTest.java
@@ -25,7 +25,7 @@ class OidcAuthTokenInterceptorTest {
     ServiceUserToken token;
 
     @Test
-    void intercept_adds_authorization_header() {
+    void intercept_adds_authorization_header() throws Exception {
         when(tokenGetter.getServiceUserToken()).thenReturn(token);
         when(token.getAccessToken()).thenReturn(ACCESS_TOKEN);
         var headers = spy(new HttpHeaders());

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/consumer/opptjeningsgrunnlag/OpptjeningsgrunnlagConsumerTest.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/consumer/opptjeningsgrunnlag/OpptjeningsgrunnlagConsumerTest.java
@@ -23,6 +23,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 
@@ -35,26 +36,23 @@ class OpptjeningsgrunnlagConsumerTest {
 
     private static final String CONSUMED_SERVICE = "PROPOPP007 hentOpptjeningsgrunnlag";
     private static final String ENDPOINT = "http://poppEndpoint.test";
+    private OpptjeningsgrunnlagConsumer consumer;
 
     @Mock
     private RestTemplate restTemplateMock;
-
-    private OpptjeningsgrunnlagConsumer consumer;
-
     @Captor
     private ArgumentCaptor<String> urlCaptor;
-
     @Captor
     private ArgumentCaptor<HttpMethod> httpMethodCaptor;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         consumer = new OpptjeningsgrunnlagConsumer(ENDPOINT);
         consumer.setRestTemplate(restTemplateMock);
     }
 
     @Test
-    void should_return_list_of_Inntekt_when_getInntektListeFromOpptjeningsgrunnlag() {
+    void should_return_listOfInntekt_when_getInntektListeFromOpptjeningsgrunnlag() {
         var response = new HentOpptjeningsGrunnlagResponse();
         var grunnlag = new OpptjeningsGrunnlagDto();
         grunnlag.setInntektListe(List.of(inntektDto()));
@@ -88,7 +86,7 @@ class OpptjeningsgrunnlagConsumerTest {
                 null,
                 HentOpptjeningsGrunnlagResponse.class)).thenThrow(new RestClientResponseException("", HttpStatus.UNAUTHORIZED.value(), "", null, null, null));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getInntektListeFromOpptjeningsgrunnlag("", 0, 0));
 
@@ -102,7 +100,7 @@ class OpptjeningsgrunnlagConsumerTest {
                 null,
                 HentOpptjeningsGrunnlagResponse.class)).thenThrow(new RestClientResponseException("PersonDoesNotExistExceptionDto", 512, "", null, null, null));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getInntektListeFromOpptjeningsgrunnlag("", 0, 0));
 
@@ -116,7 +114,7 @@ class OpptjeningsgrunnlagConsumerTest {
                 null,
                 HentOpptjeningsGrunnlagResponse.class)).thenThrow(new RestClientResponseException("", HttpStatus.INTERNAL_SERVER_ERROR.value(), "", null, null, null));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getInntektListeFromOpptjeningsgrunnlag("", 0, 0));
 
@@ -126,17 +124,17 @@ class OpptjeningsgrunnlagConsumerTest {
     }
 
     @Test
-    void should_return_FailedCallingExternalServiceException_when_RuntimeException() {
+    void should_return_FailedCallingExternalServiceException_when_RestClientException() {
         when(restTemplateMock.exchange("http://poppEndpoint.test/opptjeningsgrunnlag/?fomAr=0&tomAr=0",
                 HttpMethod.GET,
                 null,
-                HentOpptjeningsGrunnlagResponse.class)).thenThrow(new RuntimeException());
+                HentOpptjeningsGrunnlagResponse.class)).thenThrow(new RestClientException("oops"));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getInntektListeFromOpptjeningsgrunnlag("", 0, 0));
 
-        assertThat(thrown.getMessage(), is("Error when calling the external service " + CONSUMED_SERVICE + " in " + POPP + ". An error occurred in the consumer"));
+        assertThat(thrown.getMessage(), is("Error when calling the external service " + CONSUMED_SERVICE + " in " + POPP + ". Failed to access service"));
     }
 
     private static InntektDto inntektDto() {

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/consumer/pdl/PdlConsumerTest.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/consumer/pdl/PdlConsumerTest.java
@@ -3,6 +3,7 @@ package no.nav.pensjon.selvbetjeningopptjening.consumer.pdl;
 import no.nav.pensjon.selvbetjeningopptjening.TestFnrs;
 import no.nav.pensjon.selvbetjeningopptjening.auth.serviceusertoken.ServiceUserToken;
 import no.nav.pensjon.selvbetjeningopptjening.auth.serviceusertoken.ServiceUserTokenGetter;
+import no.nav.pensjon.selvbetjeningopptjening.auth.serviceusertoken.StsException;
 import no.nav.pensjon.selvbetjeningopptjening.common.domain.BirthDate;
 import no.nav.pensjon.selvbetjeningopptjening.consumer.FailedCallingExternalServiceException;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.Pid;
@@ -56,7 +57,7 @@ class PdlConsumerTest {
     }
 
     @BeforeEach
-    void initialize() {
+    void initialize() throws StsException {
         when(tokenValidationContextHolder.getTokenValidationContext()).thenReturn(tokenValidationContext());
         when(serviceUserTokenGetter.getServiceUserToken()).thenReturn(new ServiceUserToken());
         consumer = new PdlConsumer(baseUrl, tokenValidationContextHolder, serviceUserTokenGetter);
@@ -78,7 +79,7 @@ class PdlConsumerTest {
     void getBirthDates_shall_throwPdlException_when_PDL_returns_error() {
         server.enqueue(pdlErrorResponse());
 
-        PdlException exception = assertThrows(PdlException.class,
+        var exception = assertThrows(PdlException.class,
                 () -> consumer.getBirthDates(PID, LoginSecurityLevel.LEVEL4));
 
         assertEquals("Ikke tilgang til å se person", exception.getMessage());
@@ -89,7 +90,7 @@ class PdlConsumerTest {
     void getBirthDates_shall_throwFailedCallingExternalServiceException_when_PDL_returns_multipleErrors() {
         server.enqueue(pdlMultipleErrorResponse());
 
-        FailedCallingExternalServiceException exception = assertThrows(FailedCallingExternalServiceException.class,
+        var exception = assertThrows(FailedCallingExternalServiceException.class,
                 () -> consumer.getBirthDates(PID, LoginSecurityLevel.LEVEL4));
 
         assertEquals("Error when calling the external service PDL." +

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/consumer/pensjonsbeholdning/PensjonsbeholdningConsumerTest.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/consumer/pensjonsbeholdning/PensjonsbeholdningConsumerTest.java
@@ -27,6 +27,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 
@@ -88,7 +89,7 @@ class PensjonsbeholdningConsumerTest {
                 httpEntityCaptor.capture(),
                 eq(BeholdningListeResponse.class))).thenThrow(new RestClientResponseException("", HttpStatus.UNAUTHORIZED.value(), "", null, null, null));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getPensjonsbeholdning(""));
 
@@ -102,7 +103,7 @@ class PensjonsbeholdningConsumerTest {
                 httpEntityCaptor.capture(),
                 eq(BeholdningListeResponse.class))).thenThrow(new RestClientResponseException("PersonDoesNotExistExceptionDto", 512, "", null, null, null));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getPensjonsbeholdning(""));
 
@@ -116,7 +117,7 @@ class PensjonsbeholdningConsumerTest {
                 httpEntityCaptor.capture(),
                 eq(BeholdningListeResponse.class))).thenThrow(new RestClientResponseException("", HttpStatus.INTERNAL_SERVER_ERROR.value(), "", null, null, null));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getPensjonsbeholdning(""));
 
@@ -126,18 +127,18 @@ class PensjonsbeholdningConsumerTest {
     }
 
     @Test
-    void should_return_FailedCallingExternalServiceException_when_RuntimeException() {
+    void should_return_FailedCallingExternalServiceException_when_RestClientException() {
         when(restTemplateMock.exchange(eq("http://poppEndpoint.test/beholdning"),
                 eq(HttpMethod.POST),
                 httpEntityCaptor.capture(),
-                eq(BeholdningListeResponse.class))).thenThrow(new RuntimeException());
+                eq(BeholdningListeResponse.class))).thenThrow(new RestClientException("oops"));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getPensjonsbeholdning(""));
 
         assertThat(thrown.getMessage(),
-                is("Error when calling the external service " + CONSUMED_SERVICE + " in " + POPP + ". An error occurred in the consumer"));
+                is("Error when calling the external service " + CONSUMED_SERVICE + " in " + POPP + ". Failed to access service"));
     }
 
     private static BeholdningDto beholdningDto() {

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/consumer/person/PersonConsumerTest.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/consumer/person/PersonConsumerTest.java
@@ -18,6 +18,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 
@@ -90,7 +91,7 @@ class PersonConsumerTest {
     @Test
     void should_get_Uforehistorikk_when_getUforeHistorikkForPerson() {
         var historikkDto = new UforeHistorikkDto();
-        UforeperiodeDto uforeperiode = new UforeperiodeDto();
+        var uforeperiode = new UforeperiodeDto();
         uforeperiode.setUforegrad(50);
         historikkDto.setUforeperiodeListe(singletonList(uforeperiode));
         ResponseEntity<UforeHistorikkDto> entity = new ResponseEntity<>(historikkDto, HttpStatus.OK);
@@ -122,7 +123,7 @@ class PersonConsumerTest {
         when(restTemplateMock.exchange(eq(AFP_HISTORIKK_URL), any(), any(), eq(AfpHistorikkDto.class)))
                 .thenThrow(new RestClientResponseException("", HttpStatus.UNAUTHORIZED.value(), "", null, null, null));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getAfpHistorikkForPerson(""));
 
@@ -134,7 +135,7 @@ class PersonConsumerTest {
         when(restTemplateMock.exchange(eq(AFP_HISTORIKK_URL), any(), any(), eq(AfpHistorikkDto.class)))
                 .thenThrow(new RestClientResponseException("", HttpStatus.INTERNAL_SERVER_ERROR.value(), "", null, null, null));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getAfpHistorikkForPerson(""));
 
@@ -147,7 +148,7 @@ class PersonConsumerTest {
         when(restTemplateMock.exchange(eq(AFP_HISTORIKK_URL), any(), any(), eq(AfpHistorikkDto.class)))
                 .thenThrow(new RestClientResponseException("", HttpStatus.BAD_REQUEST.value(), "", null, null, null));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getAfpHistorikkForPerson(""));
 
@@ -155,15 +156,15 @@ class PersonConsumerTest {
     }
 
     @Test
-    void should_throw_FailedCallingExternalServiceException_when_RuntimeException_from_getUttaksgradForVedtak() {
+    void should_throw_FailedCallingExternalServiceException_when_RestClientException_from_getUttaksgradForVedtak() {
         when(restTemplateMock.exchange(eq(AFP_HISTORIKK_URL), any(), any(), eq(AfpHistorikkDto.class)))
-                .thenThrow(new RuntimeException());
+                .thenThrow(new RestClientException("oops"));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getAfpHistorikkForPerson(""));
 
-        assertThat(thrown.getMessage(), is("Error when calling the external service " + EXPECTED_AFP_HISTORIKK_IDENTIFIER + " in " + PEN + ". An error occurred in the consumer"));
+        assertThat(thrown.getMessage(), is("Error when calling the external service " + EXPECTED_AFP_HISTORIKK_IDENTIFIER + " in " + PEN + ". Failed to access service"));
     }
 
     @Test
@@ -171,7 +172,7 @@ class PersonConsumerTest {
         when(restTemplateMock.exchange(eq(UFOREHISTORIKK_URL), any(), any(), eq(UforeHistorikkDto.class)))
                 .thenThrow(new RestClientResponseException("", HttpStatus.UNAUTHORIZED.value(), "", null, null, null));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getUforeHistorikkForPerson(""));
 
@@ -183,7 +184,7 @@ class PersonConsumerTest {
         when(restTemplateMock.exchange(eq(UFOREHISTORIKK_URL), any(), any(), eq(UforeHistorikkDto.class)))
                 .thenThrow(new RestClientResponseException("", HttpStatus.INTERNAL_SERVER_ERROR.value(), "", null, null, null));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getUforeHistorikkForPerson(""));
 
@@ -196,7 +197,7 @@ class PersonConsumerTest {
         when(restTemplateMock.exchange(eq(UFOREHISTORIKK_URL), any(), any(), eq(UforeHistorikkDto.class)))
                 .thenThrow(new RestClientResponseException("", HttpStatus.BAD_REQUEST.value(), "", null, null, null));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getUforeHistorikkForPerson(""));
 
@@ -204,15 +205,15 @@ class PersonConsumerTest {
     }
 
     @Test
-    void should_throw_FailedCallingExternalServiceException_when_RuntimeException_from_getAlderSakUttaksgradhistorikkForPerson() {
+    void should_throw_FailedCallingExternalServiceException_when_RestClientException_from_getAlderSakUttaksgradhistorikkForPerson() {
         when(restTemplateMock.exchange(eq(UFOREHISTORIKK_URL), any(), any(), eq(UforeHistorikkDto.class)))
-                .thenThrow(new RuntimeException());
+                .thenThrow(new RestClientException("oops"));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getUforeHistorikkForPerson(""));
 
         assertThat(thrown.getMessage(),
-                is("Error when calling the external service " + EXPECTED_UFOREHISTORIKK_IDENTIFIER + " in " + PEN + ". An error occurred in the consumer"));
+                is("Error when calling the external service " + EXPECTED_UFOREHISTORIKK_IDENTIFIER + " in " + PEN + ". Failed to access service"));
     }
 }

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/consumer/restpensjon/RestpensjonConsumerTest.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/consumer/restpensjon/RestpensjonConsumerTest.java
@@ -23,6 +23,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 
@@ -65,7 +66,7 @@ class RestpensjonConsumerTest {
     }
 
     @Test
-    void should_add_fnr_as_pathrparam_when_GET_getRestpensjonListe() {
+    void should_add_fnr_as_queryParam_when_GET_getRestpensjonListe() {
         String expectedFnr = "fnrValue";
         when(rest.exchange(
                 urlCaptor.capture(),
@@ -86,7 +87,7 @@ class RestpensjonConsumerTest {
                 null,
                 RestpensjonListeResponse.class)).thenThrow(new RestClientResponseException("", HttpStatus.UNAUTHORIZED.value(), "", null, null, null));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getRestpensjonListe(""));
 
@@ -100,7 +101,7 @@ class RestpensjonConsumerTest {
                 null,
                 RestpensjonListeResponse.class)).thenThrow(new RestClientResponseException("PersonDoesNotExistExceptionDto", 512, "", null, null, null));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getRestpensjonListe(""));
 
@@ -114,7 +115,7 @@ class RestpensjonConsumerTest {
                 null,
                 RestpensjonListeResponse.class)).thenThrow(new RestClientResponseException("", HttpStatus.INTERNAL_SERVER_ERROR.value(), "", null, null, null));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getRestpensjonListe(""));
 
@@ -124,16 +125,16 @@ class RestpensjonConsumerTest {
     }
 
     @Test
-    void should_return_FailedCallingExternalServiceException_when_RuntimeException() {
+    void should_return_FailedCallingExternalServiceException_when_RestClientException() {
         when(rest.exchange("http://poppEndpoint.test/restpensjon/?hentSiste=false",
                 HttpMethod.GET,
                 null,
-                RestpensjonListeResponse.class)).thenThrow(new RuntimeException());
+                RestpensjonListeResponse.class)).thenThrow(new RestClientException("oops"));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getRestpensjonListe(""));
 
-        assertThat(thrown.getMessage(), is("Error when calling the external service " + CONSUMED_SERVICE + " in " + POPP + ". An error occurred in the consumer"));
+        assertThat(thrown.getMessage(), is("Error when calling the external service " + CONSUMED_SERVICE + " in " + POPP + ". Failed to access service"));
     }
 }

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/consumer/uttaksgrad/UttaksgradConsumerTest.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/consumer/uttaksgrad/UttaksgradConsumerTest.java
@@ -27,6 +27,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.client.RestTemplate;
 
@@ -52,13 +53,13 @@ class UttaksgradConsumerTest {
     private ArgumentCaptor<HttpEntity<Object>> httpEntityCaptor;
 
     @BeforeEach
-    void setup() {
+    void setUp() {
         consumer = new UttaksgradConsumer(ENDPOINT);
         consumer.setRestTemplate(rest);
     }
 
     @Test
-    void should_return_list_of_uttaksgrad_when_getUttaksgradForVedtak() {
+    void should_return_listOfUttaksgrad_when_getUttaksgradForVedtak() {
         var expectedResponse = new UttaksgradListResponse();
         var uttaksgradDto = new UttaksgradDto();
         uttaksgradDto.setFomDato(DATE);
@@ -118,7 +119,7 @@ class UttaksgradConsumerTest {
         when(rest.exchange(eq(SEARCH_ENDPOINT_PATH), any(), any(), eq(UttaksgradListResponse.class)))
                 .thenThrow(new RestClientResponseException("", HttpStatus.UNAUTHORIZED.value(), "", null, null, null));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getUttaksgradForVedtak(new ArrayList<>()));
 
@@ -130,7 +131,7 @@ class UttaksgradConsumerTest {
         when(rest.exchange(eq(SEARCH_ENDPOINT_PATH), any(), any(), eq(UttaksgradListResponse.class)))
                 .thenThrow(new RestClientResponseException("", HttpStatus.INTERNAL_SERVER_ERROR.value(), "", null, null, null));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getUttaksgradForVedtak(new ArrayList<>()));
 
@@ -143,7 +144,7 @@ class UttaksgradConsumerTest {
         when(rest.exchange(eq(SEARCH_ENDPOINT_PATH), any(), any(), eq(UttaksgradListResponse.class)))
                 .thenThrow(new RestClientResponseException("", HttpStatus.BAD_REQUEST.value(), "", null, null, null));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getUttaksgradForVedtak(new ArrayList<>()));
 
@@ -151,15 +152,15 @@ class UttaksgradConsumerTest {
     }
 
     @Test
-    void should_throw_FailedCallingExternalServiceException_when_RuntimeException_from_getUttaksgradForVedtak() {
+    void should_throw_FailedCallingExternalServiceException_when_RestClientException_from_getUttaksgradForVedtak() {
         when(rest.exchange(eq(SEARCH_ENDPOINT_PATH), any(), any(), eq(UttaksgradListResponse.class)))
-                .thenThrow(new RuntimeException());
+                .thenThrow(new RestClientException("oops"));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getUttaksgradForVedtak(new ArrayList<>()));
 
-        assertThat(thrown.getMessage(), is("Error when calling the external service PROPEN3000 getUttaksgradForVedtak in " + PEN + ". An error occurred in the consumer"));
+        assertThat(thrown.getMessage(), is("Error when calling the external service PROPEN3000 getUttaksgradForVedtak in " + PEN + ". Failed to access service"));
     }
 
     @Test
@@ -167,7 +168,7 @@ class UttaksgradConsumerTest {
         when(rest.exchange(eq(PERSON_ENDPOINT_PATH), any(), any(), eq(UttaksgradListResponse.class)))
                 .thenThrow(new RestClientResponseException("", HttpStatus.UNAUTHORIZED.value(), "", null, null, null));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getAlderSakUttaksgradhistorikkForPerson(""));
 
@@ -179,7 +180,7 @@ class UttaksgradConsumerTest {
         when(rest.exchange(eq(PERSON_ENDPOINT_PATH), any(), any(), eq(UttaksgradListResponse.class)))
                 .thenThrow(new RestClientResponseException("", HttpStatus.INTERNAL_SERVER_ERROR.value(), "", null, null, null));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getAlderSakUttaksgradhistorikkForPerson(""));
 
@@ -192,7 +193,7 @@ class UttaksgradConsumerTest {
         when(rest.exchange(eq(PERSON_ENDPOINT_PATH), any(), any(), eq(UttaksgradListResponse.class)))
                 .thenThrow(new RestClientResponseException("", HttpStatus.BAD_REQUEST.value(), "", null, null, null));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getAlderSakUttaksgradhistorikkForPerson(""));
 
@@ -200,15 +201,15 @@ class UttaksgradConsumerTest {
     }
 
     @Test
-    void should_throw_FailedCallingExternalServiceException_when_RuntimeException_from_getAlderSakUttaksgradhistorikkForPerson() {
+    void should_throw_FailedCallingExternalServiceException_when_RestClientException_from_getAlderSakUttaksgradhistorikkForPerson() {
         when(rest.exchange(eq(PERSON_ENDPOINT_PATH), any(), any(), eq(UttaksgradListResponse.class)))
-                .thenThrow(new RuntimeException());
+                .thenThrow(new RestClientException("oops"));
 
-        FailedCallingExternalServiceException thrown = assertThrows(
+        var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
                 () -> consumer.getAlderSakUttaksgradhistorikkForPerson(""));
 
         assertThat(thrown.getMessage(),
-                is("Error when calling the external service PROPEN3001 getAlderSakUttaksgradhistorikkForPerson in " + PEN + ". An error occurred in the consumer"));
+                is("Error when calling the external service PROPEN3001 getAlderSakUttaksgradhistorikkForPerson in " + PEN + ". Failed to access service"));
     }
 }

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/health/ReadinessEndpointTest.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/health/ReadinessEndpointTest.java
@@ -1,12 +1,11 @@
 package no.nav.pensjon.selvbetjeningopptjening.health;
 
 import no.nav.pensjon.selvbetjeningopptjening.SelvbetjeningOpptjeningApplication;
-import no.nav.pensjon.selvbetjeningopptjening.opptjening.OpptjeningProvider;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -18,9 +17,8 @@ class ReadinessEndpointTest {
 
     @Autowired
     private MockMvc mvc;
-
     @MockBean
-    OpptjeningProvider provider;
+    Selftest selftest;
 
     @Test
     void isAlive() throws Exception {


### PR DESCRIPTION
- Makes selftest report status of services as JSON; http://localhost:8080/api/internal/selftest
- Improves handling of connection problem to services
- Fixes NullPointer issue caused by null-return in OidcAuthTokenInterceptor
- Avoids catching general Exception