### PR TITLE
Epoch conversion timezone

### DIFF
--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/util/LocalDateTimeFromEpochDeserializer.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/util/LocalDateTimeFromEpochDeserializer.java
@@ -11,6 +11,8 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 
 public class LocalDateTimeFromEpochDeserializer extends StdDeserializer<LocalDate> {
 
+    private static final String TIME_ZONE = "UTC+1"; // Norway winter time
+
     public LocalDateTimeFromEpochDeserializer() {
         super(LocalDate.class);
     }
@@ -18,6 +20,6 @@ public class LocalDateTimeFromEpochDeserializer extends StdDeserializer<LocalDat
     @Override
     public LocalDate deserialize(JsonParser parser, DeserializationContext context) throws IOException {
         var instant = Instant.ofEpochMilli(parser.readValueAs(Long.class));
-        return instant.atZone(ZoneId.systemDefault()).toLocalDate();
+        return instant.atZone(ZoneId.of(TIME_ZONE)).toLocalDate();
     }
 }

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/consumer/pensjonsbeholdning/PensjonsbeholdningConsumerTest.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/consumer/pensjonsbeholdning/PensjonsbeholdningConsumerTest.java
@@ -91,10 +91,8 @@ class PensjonsbeholdningConsumerTest extends WebClientTest {
         assertEquals("PEN_B", beholdning.getType());
         assertEquals(20137.460428429236D, beholdning.getBelop());
         assertFalse(beholdning.hasVedtak());
-        /* Probably susceptible to time-zone issues:
         assertEquals(LocalDate.of(1994, 1, 1), beholdning.getFomDato());
         assertEquals(LocalDate.of(1994, 12, 31), beholdning.getTomDato());
-        */
         assertEquals(108655.1D, beholdning.getGrunnlag());
         assertEquals(108655.0D, beholdning.getGrunnlagAvkortet());
         assertEquals(20137.460428429236D, beholdning.getInnskudd());

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/consumer/person/PersonConsumerTest.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/consumer/person/PersonConsumerTest.java
@@ -1,219 +1,282 @@
 package no.nav.pensjon.selvbetjeningopptjening.consumer.person;
 
+import no.nav.pensjon.selvbetjeningopptjening.SelvbetjeningOpptjeningApplication;
+import no.nav.pensjon.selvbetjeningopptjening.auth.serviceusertoken.ServiceUserToken;
+import no.nav.pensjon.selvbetjeningopptjening.auth.serviceusertoken.ServiceUserTokenGetter;
+import no.nav.pensjon.selvbetjeningopptjening.auth.serviceusertoken.StsException;
 import no.nav.pensjon.selvbetjeningopptjening.consumer.FailedCallingExternalServiceException;
-import no.nav.pensjon.selvbetjeningopptjening.model.AfpHistorikkDto;
-import no.nav.pensjon.selvbetjeningopptjening.model.UforeHistorikkDto;
-import no.nav.pensjon.selvbetjeningopptjening.model.UforeperiodeDto;
+import no.nav.pensjon.selvbetjeningopptjening.mock.WebClientTest;
+import no.nav.pensjon.selvbetjeningopptjening.model.code.UforeTypeCode;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.AfpHistorikk;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.UforeHistorikk;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.Uforeperiode;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.*;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpMethod;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.client.RestClientException;
-import org.springframework.web.client.RestClientResponseException;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Objects;
 
-import static java.util.Collections.singletonList;
-import static no.nav.pensjon.selvbetjeningopptjening.util.Constants.PEN;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(MockitoExtension.class)
-class PersonConsumerTest {
+@SpringBootTest
+@ContextConfiguration(classes = SelvbetjeningOpptjeningApplication.class)
+@TestPropertySource(properties = "fnr=dummy")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class PersonConsumerTest extends WebClientTest {
 
-    private static final String ENDPOINT = "http://penEndpoint.test";
-    private static final String AFP_HISTORIKK_URL = ENDPOINT + "/person/afphistorikk";
-    private static final String UFOREHISTORIKK_URL = ENDPOINT + "/person/uforehistorikk";
     private static final String EXPECTED_AFP_HISTORIKK_IDENTIFIER = "PROPEN2602 getAfphistorikkForPerson";
     private static final String EXPECTED_UFOREHISTORIKK_IDENTIFIER = "PROPEN2603 getUforehistorikkForPerson";
-    private static final LocalDate DATE = LocalDate.of(1991, 1, 1);
+    private static final String EXPECTED_AFP_HISTORIKK_ERROR_MESSAGE = "Error when calling the external service " + EXPECTED_AFP_HISTORIKK_IDENTIFIER + " in PEN.";
+    private static final String EXPECTED_UFORE_HISTORIKK_ERROR_MESSAGE = "Error when calling the external service " + EXPECTED_UFOREHISTORIKK_IDENTIFIER + " in PEN.";
+    private static final ServiceUserToken TOKEN = new ServiceUserToken("token", 1L, "type");
     private PersonConsumer consumer;
 
+    @Autowired
+    @Qualifier("epoch-support")
+    WebClient webClient;
+
     @Mock
-    private RestTemplate restTemplateMock;
-    @Captor
-    private ArgumentCaptor<String> urlCaptor;
-    @Captor
-    private ArgumentCaptor<HttpMethod> httpMethodCaptor;
-    @Captor
-    private ArgumentCaptor<HttpEntity<Object>> httpEntityCaptor;
+    ServiceUserTokenGetter tokenGetter;
 
     @BeforeEach
-    void setup() {
-        consumer = new PersonConsumer(ENDPOINT);
-        consumer.setRestTemplate(restTemplateMock);
+    void initialize() throws StsException {
+        when(tokenGetter.getServiceUserToken()).thenReturn(TOKEN);
+        consumer = new PersonConsumer(webClient, baseUrl(), tokenGetter);
     }
 
     @Test
-    void should_return_Afphistorikk_when_getAfpHistorikkForPerson() {
-        var dto = new AfpHistorikkDto();
-        dto.setVirkFom(DATE);
-        ResponseEntity<AfpHistorikkDto> entity = new ResponseEntity<>(dto, HttpStatus.OK);
-        when(restTemplateMock.exchange(eq(AFP_HISTORIKK_URL), any(), any(), eq(AfpHistorikkDto.class))).thenReturn(entity);
+    @Order(1)
+    void getUforeHistorikkForPerson_returns_uforeHistorikk_when_ok() throws InterruptedException {
+        prepare(uforeHistorikkResponse());
 
-        AfpHistorikk historikk = consumer.getAfpHistorikkForPerson("");
+        UforeHistorikk historikk = consumer.getUforeHistorikkForPerson("fnr");
 
-        assertEquals(DATE, historikk.getVirkningFomDate());
-    }
-
-    @Test
-    void should_add_fnr_as_headerparam_in_GET_when_getAfpHistorikkForPerson() {
-        String expectedFnr = "expFnr";
-        when(restTemplateMock.exchange(urlCaptor.capture(), httpMethodCaptor.capture(), httpEntityCaptor.capture(), eq(AfpHistorikkDto.class)))
-                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
-
-        consumer.getAfpHistorikkForPerson(expectedFnr);
-
-        assertThat(httpMethodCaptor.getValue(), is(HttpMethod.GET));
-        assertThat(urlCaptor.getValue(), is(AFP_HISTORIKK_URL));
-        assertThat("Request should contain header pid", httpEntityCaptor.getValue().getHeaders().containsKey("pid"), is(true));
-        assertThat(Objects.requireNonNull(httpEntityCaptor.getValue().getHeaders().get("pid")).get(0), is(expectedFnr));
-    }
-
-    @Test
-    void should_get_Uforehistorikk_when_getUforeHistorikkForPerson() {
-        var historikkDto = new UforeHistorikkDto();
-        var uforeperiode = new UforeperiodeDto();
-        uforeperiode.setUforegrad(50);
-        historikkDto.setUforeperiodeListe(singletonList(uforeperiode));
-        ResponseEntity<UforeHistorikkDto> entity = new ResponseEntity<>(historikkDto, HttpStatus.OK);
-        when(restTemplateMock.exchange(eq(UFOREHISTORIKK_URL), any(), any(), eq(UforeHistorikkDto.class))).thenReturn(entity);
-
-        UforeHistorikk historikk = consumer.getUforeHistorikkForPerson("");
-
+        RecordedRequest request = takeRequest();
+        HttpUrl requestUrl = request.getRequestUrl();
+        assertNotNull(requestUrl);
+        assertEquals("GET", request.getMethod());
+        assertEquals("Bearer token", request.getHeader(HttpHeaders.AUTHORIZATION));
+        assertEquals("fnr", request.getHeader("pid"));
         List<Uforeperiode> perioder = historikk.getUforeperioder();
         assertEquals(1, perioder.size());
-        assertEquals(50, perioder.get(0).getUforegrad());
+        Uforeperiode periode = perioder.get(0);
+        assertEquals(100, periode.getUforegrad());
+        assertEquals(UforeTypeCode.UFORE, periode.getUforetype());
+        assertEquals(LocalDate.of(2019, 10, 1), periode.getFomDate());
+        assertFalse(periode.hasTomDate());
+        assertNull(periode.getTomDate());
     }
 
     @Test
-    void should_add_fnr_as_headerparam_in_GET_when_getUforehistorikkForPerson() {
-        String expectedFnr = "expFnr";
-        when(restTemplateMock.exchange(urlCaptor.capture(), httpMethodCaptor.capture(), httpEntityCaptor.capture(), eq(UforeHistorikkDto.class)))
-                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+    @Order(2)
+    void getAfpHistorikkForPerson_returns_null_when_noData() throws InterruptedException {
+        prepare(emptyResponse());
 
-        consumer.getUforeHistorikkForPerson(expectedFnr);
+        AfpHistorikk historikk = consumer.getAfpHistorikkForPerson("fnr");
 
-        assertThat(httpMethodCaptor.getValue(), is(HttpMethod.GET));
-        assertThat(urlCaptor.getValue(), is(UFOREHISTORIKK_URL));
-        assertThat("Request should contain header pid", httpEntityCaptor.getValue().getHeaders().containsKey("pid"), is(true));
-        assertThat(Objects.requireNonNull(httpEntityCaptor.getValue().getHeaders().get("pid")).get(0), is(expectedFnr));
+        RecordedRequest request = takeRequest();
+        HttpUrl requestUrl = request.getRequestUrl();
+        assertNotNull(requestUrl);
+        assertEquals("GET", request.getMethod());
+        assertEquals("Bearer token", request.getHeader(HttpHeaders.AUTHORIZATION));
+        assertEquals("fnr", request.getHeader("pid"));
+        assertNull(historikk);
     }
 
     @Test
-    void should_throw_FailedCallingExternalServiceException_when_401_from_getAfphistorikkForPerson() {
-        when(restTemplateMock.exchange(eq(AFP_HISTORIKK_URL), any(), any(), eq(AfpHistorikkDto.class)))
-                .thenThrow(new RestClientResponseException("", HttpStatus.UNAUTHORIZED.value(), "", null, null, null));
+    @Order(3)
+    void ping_ok() throws InterruptedException {
+        prepare(pingResponse());
+
+        consumer.ping();
+
+        RecordedRequest request = takeRequest();
+        HttpUrl requestUrl = request.getRequestUrl();
+        assertNotNull(requestUrl);
+        assertEquals("GET", request.getMethod());
+        assertEquals("Bearer token", request.getHeader(HttpHeaders.AUTHORIZATION));
+    }
+
+    @Order(4)
+    @Test
+    void getUforeHistorikkForPerson_throws_FailedCallingExternalServiceException_when_invalidPid() {
+        prepare(invalidPidResponse());
 
         var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
-                () -> consumer.getAfpHistorikkForPerson(""));
-
-        assertThat(thrown.getMessage(), is("Error when calling the external service " + EXPECTED_AFP_HISTORIKK_IDENTIFIER + " in " + PEN + ". Received 401 UNAUTHORIZED"));
-    }
-
-    @Test
-    void should_throw_FailedCallingExternalServiceException_when_500_from_getUttaksgradForVedtak() {
-        when(restTemplateMock.exchange(eq(AFP_HISTORIKK_URL), any(), any(), eq(AfpHistorikkDto.class)))
-                .thenThrow(new RestClientResponseException("", HttpStatus.INTERNAL_SERVER_ERROR.value(), "", null, null, null));
-
-        var thrown = assertThrows(
-                FailedCallingExternalServiceException.class,
-                () -> consumer.getAfpHistorikkForPerson(""));
-
-        assertThat(thrown.getMessage(), is("Error when calling the external service " + EXPECTED_AFP_HISTORIKK_IDENTIFIER + " in " + PEN
-                + ". An error occurred in the provider, received 500 INTERNAL SERVER ERROR"));
-    }
-
-    @Test
-    void should_throw_FailedCallingExternalServiceException_when_400_from_getUttaksgradForVedtak() {
-        when(restTemplateMock.exchange(eq(AFP_HISTORIKK_URL), any(), any(), eq(AfpHistorikkDto.class)))
-                .thenThrow(new RestClientResponseException("", HttpStatus.BAD_REQUEST.value(), "", null, null, null));
-
-        var thrown = assertThrows(
-                FailedCallingExternalServiceException.class,
-                () -> consumer.getAfpHistorikkForPerson(""));
-
-        assertThat(thrown.getMessage(), is("Error when calling the external service " + EXPECTED_AFP_HISTORIKK_IDENTIFIER + " in " + PEN + ". Received 400 BAD REQUEST"));
-    }
-
-    @Test
-    void should_throw_FailedCallingExternalServiceException_when_RestClientException_from_getUttaksgradForVedtak() {
-        when(restTemplateMock.exchange(eq(AFP_HISTORIKK_URL), any(), any(), eq(AfpHistorikkDto.class)))
-                .thenThrow(new RestClientException("oops"));
-
-        var thrown = assertThrows(
-                FailedCallingExternalServiceException.class,
-                () -> consumer.getAfpHistorikkForPerson(""));
-
-        assertThat(thrown.getMessage(), is("Error when calling the external service " + EXPECTED_AFP_HISTORIKK_IDENTIFIER + " in " + PEN + ". Failed to access service"));
-    }
-
-    @Test
-    void should_throw_FailedCallingExternalServiceException_when_401_from_getAlderSakUttaksgradhistorikkForPerson() {
-        when(restTemplateMock.exchange(eq(UFOREHISTORIKK_URL), any(), any(), eq(UforeHistorikkDto.class)))
-                .thenThrow(new RestClientResponseException("", HttpStatus.UNAUTHORIZED.value(), "", null, null, null));
-
-        var thrown = assertThrows(
-                FailedCallingExternalServiceException.class,
-                () -> consumer.getUforeHistorikkForPerson(""));
-
-        assertThat(thrown.getMessage(), is("Error when calling the external service " + EXPECTED_UFOREHISTORIKK_IDENTIFIER + " in " + PEN + ". Received 401 UNAUTHORIZED"));
-    }
-
-    @Test
-    void should_throw_FailedCallingExternalServiceException_when_500_from_getAlderSakUttaksgradhistorikkForPerson() {
-        when(restTemplateMock.exchange(eq(UFOREHISTORIKK_URL), any(), any(), eq(UforeHistorikkDto.class)))
-                .thenThrow(new RestClientResponseException("", HttpStatus.INTERNAL_SERVER_ERROR.value(), "", null, null, null));
-
-        var thrown = assertThrows(
-                FailedCallingExternalServiceException.class,
-                () -> consumer.getUforeHistorikkForPerson(""));
-
-        assertThat(thrown.getMessage(), is("Error when calling the external service " + EXPECTED_UFOREHISTORIKK_IDENTIFIER + " in " + PEN
-                + ". An error occurred in the provider, received 500 INTERNAL SERVER ERROR"));
-    }
-
-    @Test
-    void should_throw_FailedCallingExternalServiceException_when_400_from_getAlderSakUttaksgradhistorikkForPerson() {
-        when(restTemplateMock.exchange(eq(UFOREHISTORIKK_URL), any(), any(), eq(UforeHistorikkDto.class)))
-                .thenThrow(new RestClientResponseException("", HttpStatus.BAD_REQUEST.value(), "", null, null, null));
-
-        var thrown = assertThrows(
-                FailedCallingExternalServiceException.class,
-                () -> consumer.getUforeHistorikkForPerson(""));
-
-        assertThat(thrown.getMessage(), is("Error when calling the external service " + EXPECTED_UFOREHISTORIKK_IDENTIFIER + " in " + PEN + ". Received 400 BAD REQUEST"));
-    }
-
-    @Test
-    void should_throw_FailedCallingExternalServiceException_when_RestClientException_from_getAlderSakUttaksgradhistorikkForPerson() {
-        when(restTemplateMock.exchange(eq(UFOREHISTORIKK_URL), any(), any(), eq(UforeHistorikkDto.class)))
-                .thenThrow(new RestClientException("oops"));
-
-        var thrown = assertThrows(
-                FailedCallingExternalServiceException.class,
-                () -> consumer.getUforeHistorikkForPerson(""));
+                () -> consumer.getUforeHistorikkForPerson("fnr"));
 
         assertThat(thrown.getMessage(),
-                is("Error when calling the external service " + EXPECTED_UFOREHISTORIKK_IDENTIFIER + " in " + PEN + ". Failed to access service"));
+                is(EXPECTED_UFORE_HISTORIKK_ERROR_MESSAGE + " Received 400 BAD REQUEST"));
+    }
+
+    @Test
+    @Order(5)
+    void getUforeHistorikkForPerson_throws_FailedCallingExternalServiceException_when_expiredToken() {
+        prepare(expiredTokenResponse());
+
+        var thrown = assertThrows(
+                FailedCallingExternalServiceException.class,
+                () -> consumer.getUforeHistorikkForPerson("fnr"));
+
+        assertThat(thrown.getMessage(),
+                is(EXPECTED_UFORE_HISTORIKK_ERROR_MESSAGE +
+                        " An error occurred in the provider, received 500 INTERNAL SERVER ERROR"));
+    }
+
+    @Test
+    @Order(6)
+    void getUforeHistorikkForPerson_throws_FailedCallingExternalServiceException_when_invalidToken() {
+        prepare(invalidTokenResponse());
+
+        var thrown = assertThrows(
+                FailedCallingExternalServiceException.class,
+                () -> consumer.getUforeHistorikkForPerson("fnr"));
+
+        assertThat(thrown.getMessage(),
+                is(EXPECTED_UFORE_HISTORIKK_ERROR_MESSAGE +
+                        " An error occurred in the provider, received 500 INTERNAL SERVER ERROR"));
+    }
+
+    @Order(7)
+    @Test
+    void getAfpHistorikkForPerson_throws_FailedCallingExternalServiceException_when_invalidPid() {
+        prepare(invalidPidResponse());
+
+        var thrown = assertThrows(
+                FailedCallingExternalServiceException.class,
+                () -> consumer.getAfpHistorikkForPerson("fnr"));
+
+        assertThat(thrown.getMessage(),
+                is(EXPECTED_AFP_HISTORIKK_ERROR_MESSAGE + " Received 400 BAD REQUEST"));
+    }
+
+    private static MockResponse uforeHistorikkResponse() {
+        return jsonResponse()
+                .setBody("{\n" +
+                        "    \"garantigradYrke\": null,\n" +
+                        "    \"reaktiviseringFomDato\": null,\n" +
+                        "    \"uforeperiodeListe\": [\n" +
+                        "        {\n" +
+                        "            \"uforegrad\": 100,\n" +
+                        "            \"uforeperiodeId\": 500326589,\n" +
+                        "            \"uforetidspunkt\": 1569880800000,\n" +
+                        "            \"virk\": 1580511600000,\n" +
+                        "            \"uforetype\": \"UFORE\",\n" +
+                        "            \"fppGarantiKode\": null,\n" +
+                        "            \"redusertAntFppAr\": 0,\n" +
+                        "            \"fpp\": 0.0,\n" +
+                        "            \"uforetidspunktTom\": null,\n" +
+                        "            \"fppGaranti\": 0.0,\n" +
+                        "            \"fpp_omregnet\": 0.0,\n" +
+                        "            \"spt_pa_f92\": 0,\n" +
+                        "            \"spt_pa_e91\": 0,\n" +
+                        "            \"opt_pa_f92\": 0,\n" +
+                        "            \"opt_pa_e91\": 0,\n" +
+                        "            \"ypt_pa_f92\": 0,\n" +
+                        "            \"ypt_pa_e91\": 0,\n" +
+                        "            \"spt_eos\": 0.0,\n" +
+                        "            \"spt_pa_e91_eos\": 0,\n" +
+                        "            \"spt_pa_f92_eos\": 0,\n" +
+                        "            \"spt\": 0.0,\n" +
+                        "            \"opt\": 0.0,\n" +
+                        "            \"ypt\": 0.0,\n" +
+                        "            \"paa\": 0.0,\n" +
+                        "            \"ufgFom\": 1569880800000,\n" +
+                        "            \"ufgTom\": null,\n" +
+                        "            \"proRataNevner\": null,\n" +
+                        "            \"proRataTeller\": null,\n" +
+                        "            \"proRataBeregningType\": null,\n" +
+                        "            \"redusertAntFppArProRata\": null,\n" +
+                        "            \"sptProRata\": null,\n" +
+                        "            \"fodselsArYngsteBarn\": 0\n" +
+                        "        }\n" +
+                        "    ],\n" +
+                        "    \"lonnstilskuddTomDato\": null,\n" +
+                        "    \"frysHvilPensjTomDato\": null,\n" +
+                        "    \"forlengelseFrysTomDato\": null,\n" +
+                        "    \"uforehistorikkId\": 557901588,\n" +
+                        "    \"garantigrad\": null,\n" +
+                        "    \"lonnstilskuddFomDato\": null,\n" +
+                        "    \"frysHvilPensjFomDato\": null,\n" +
+                        "    \"reaktiviseringTomDato\": null,\n" +
+                        "    \"ungUfor\": false,\n" +
+                        "    \"forlengelseFrysFomDato\": null\n" +
+                        "}");
+    }
+
+    private static MockResponse invalidPidResponse() {
+        return jsonResponse(HttpStatus.BAD_REQUEST)
+                .setBody("{\n" +
+                        "    \"feil\": \"SimplePidParamConverter: Invalid pid as input to REST service\"\n" +
+                        "}");
+    }
+
+    private static MockResponse expiredTokenResponse() {
+        return new MockResponse()
+                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_HTML_VALUE)
+                .setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                .setBody("<!doctype html>\n" +
+                        "<html lang=\"en\">\n" +
+                        "<head>\n" +
+                        "  <title>HTTP Status 500 – Internal Server Error</title>\n" +
+                        "</head>\n" +
+                        "<body>\n" +
+                        "  <h1>HTTP Status 500 – Internal Server Error</h1>\n" +
+                        "  <p><b>Type</b> Exception Report</p>\n" +
+                        "  <p><b>Message</b> JWT token is not valid: JWT\n" +
+                        "    (claims-&gt;{&quot;sub&quot;:&quot;srvpensjon&quot;,&quot;aud&quot;:[&quot;srvpensjon&quot;,&quot;preprod.local&quot;],&quot;ver&quot;:&quot;1.0&quot;,&quot;nbf&quot;:1612199803,&quot;azp&quot;:&quot;srvpensjon&quot;,&quot;identType&quot;:&quot;Systemressurs&quot;,&quot;auth_time&quot;:1612199803,&quot;iss&quot;:&quot;https:\\&#47;\\&#47;security-token-service.nais.preprod.local&quot;,&quot;exp&quot;:1612203403,&quot;iat&quot;:1612199803,&quot;jti&quot;:&quot;b6307b4b-db49-4b35-86f7-4d1b8c83d63e&quot;})\n" +
+                        "    rejected due to invalid claims. Additional details: [[1] The JWT is no longer valid - the evaluation time\n" +
+                        "    NumericDate{1612215217 -&gt; Feb 1, 2021 10:33:37 PM CET} is on or after the Expiration Time\n" +
+                        "    (exp=NumericDate{1612203403 -&gt; Feb 1, 2021 7:16:43 PM CET}) claim value (even when providing 20 seconds of\n" +
+                        "    leeway to account for clock skew).]</p>\n" +
+                        "  <p><b>Description</b> The server encountered an unexpected condition that prevented it from fulfilling the request.\n" +
+                        "  </p>\n" +
+                        "</body>\n" +
+                        "</html>");
+    }
+
+    private static MockResponse invalidTokenResponse() {
+        return new MockResponse()
+                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_HTML_VALUE)
+                .setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                .setBody("<!doctype html>\n" +
+                        "<html lang=\"en\">\n" +
+                        "<body>\n" +
+                        "  <h1>HTTP Status 500 – Internal Server Error</h1>\n" +
+                        "  <p><b>Type</b> Exception Report</p>\n" +
+                        "  <p><b>Message</b> JWT token is not valid: JWT rejected due to invalid signature. Additional details: [[9] Invalid\n" +
+                        "    JWS Signature:\n" +
+                        "    JsonWebSignature{&quot;kid&quot;:&quot;758677f4-88bb-4400-a0d0-e7c8a8325037&quot;,&quot;typ&quot;:&quot;JWT&quot;,&quot;alg&quot;:&quot;RS256&quot;}-&gt;eyJ...6vD]\n" +
+                        "  </p>\n" +
+                        "  <p><b>Description</b> The server encountered an unexpected condition that prevented it from fulfilling the request.\n" +
+                        "  </p>\n" +
+                        "</body>\n" +
+                        "</html>");
+    }
+
+    private static MockResponse pingResponse() {
+        return jsonResponse() // PEN responds with 'application/json' despite plaintext body
+                .setBody("Service online!");
+    }
+
+    private static MockResponse emptyResponse() {
+        return jsonResponse()
+                .setBody("");
     }
 }

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/consumer/person/PersonConsumerTest.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/consumer/person/PersonConsumerTest.java
@@ -1,282 +1,219 @@
 package no.nav.pensjon.selvbetjeningopptjening.consumer.person;
 
-import no.nav.pensjon.selvbetjeningopptjening.SelvbetjeningOpptjeningApplication;
-import no.nav.pensjon.selvbetjeningopptjening.auth.serviceusertoken.ServiceUserToken;
-import no.nav.pensjon.selvbetjeningopptjening.auth.serviceusertoken.ServiceUserTokenGetter;
-import no.nav.pensjon.selvbetjeningopptjening.auth.serviceusertoken.StsException;
 import no.nav.pensjon.selvbetjeningopptjening.consumer.FailedCallingExternalServiceException;
-import no.nav.pensjon.selvbetjeningopptjening.mock.WebClientTest;
-import no.nav.pensjon.selvbetjeningopptjening.model.code.UforeTypeCode;
+import no.nav.pensjon.selvbetjeningopptjening.model.AfpHistorikkDto;
+import no.nav.pensjon.selvbetjeningopptjening.model.UforeHistorikkDto;
+import no.nav.pensjon.selvbetjeningopptjening.model.UforeperiodeDto;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.AfpHistorikk;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.UforeHistorikk;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.Uforeperiode;
-import okhttp3.HttpUrl;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.RecordedRequest;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.HttpHeaders;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.client.RestTemplate;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
 
+import static java.util.Collections.singletonList;
+import static no.nav.pensjon.selvbetjeningopptjening.util.Constants.PEN;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-@SpringBootTest
-@ContextConfiguration(classes = SelvbetjeningOpptjeningApplication.class)
-@TestPropertySource(properties = "fnr=dummy")
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-class PersonConsumerTest extends WebClientTest {
+@ExtendWith(MockitoExtension.class)
+class PersonConsumerTest {
 
+    private static final String ENDPOINT = "http://penEndpoint.test";
+    private static final String AFP_HISTORIKK_URL = ENDPOINT + "/person/afphistorikk";
+    private static final String UFOREHISTORIKK_URL = ENDPOINT + "/person/uforehistorikk";
     private static final String EXPECTED_AFP_HISTORIKK_IDENTIFIER = "PROPEN2602 getAfphistorikkForPerson";
     private static final String EXPECTED_UFOREHISTORIKK_IDENTIFIER = "PROPEN2603 getUforehistorikkForPerson";
-    private static final String EXPECTED_AFP_HISTORIKK_ERROR_MESSAGE = "Error when calling the external service " + EXPECTED_AFP_HISTORIKK_IDENTIFIER + " in PEN.";
-    private static final String EXPECTED_UFORE_HISTORIKK_ERROR_MESSAGE = "Error when calling the external service " + EXPECTED_UFOREHISTORIKK_IDENTIFIER + " in PEN.";
-    private static final ServiceUserToken TOKEN = new ServiceUserToken("token", 1L, "type");
+    private static final LocalDate DATE = LocalDate.of(1991, 1, 1);
     private PersonConsumer consumer;
 
-    @Autowired
-    @Qualifier("epoch-support")
-    WebClient webClient;
-
     @Mock
-    ServiceUserTokenGetter tokenGetter;
+    private RestTemplate restTemplateMock;
+    @Captor
+    private ArgumentCaptor<String> urlCaptor;
+    @Captor
+    private ArgumentCaptor<HttpMethod> httpMethodCaptor;
+    @Captor
+    private ArgumentCaptor<HttpEntity<Object>> httpEntityCaptor;
 
     @BeforeEach
-    void initialize() throws StsException {
-        when(tokenGetter.getServiceUserToken()).thenReturn(TOKEN);
-        consumer = new PersonConsumer(webClient, baseUrl(), tokenGetter);
+    void setup() {
+        consumer = new PersonConsumer(ENDPOINT);
+        consumer.setRestTemplate(restTemplateMock);
     }
 
     @Test
-    @Order(1)
-    void getUforeHistorikkForPerson_returns_uforeHistorikk_when_ok() throws InterruptedException {
-        prepare(uforeHistorikkResponse());
+    void should_return_Afphistorikk_when_getAfpHistorikkForPerson() {
+        var dto = new AfpHistorikkDto();
+        dto.setVirkFom(DATE);
+        ResponseEntity<AfpHistorikkDto> entity = new ResponseEntity<>(dto, HttpStatus.OK);
+        when(restTemplateMock.exchange(eq(AFP_HISTORIKK_URL), any(), any(), eq(AfpHistorikkDto.class))).thenReturn(entity);
 
-        UforeHistorikk historikk = consumer.getUforeHistorikkForPerson("fnr");
+        AfpHistorikk historikk = consumer.getAfpHistorikkForPerson("");
 
-        RecordedRequest request = takeRequest();
-        HttpUrl requestUrl = request.getRequestUrl();
-        assertNotNull(requestUrl);
-        assertEquals("GET", request.getMethod());
-        assertEquals("Bearer token", request.getHeader(HttpHeaders.AUTHORIZATION));
-        assertEquals("fnr", request.getHeader("pid"));
+        assertEquals(DATE, historikk.getVirkningFomDate());
+    }
+
+    @Test
+    void should_add_fnr_as_headerparam_in_GET_when_getAfpHistorikkForPerson() {
+        String expectedFnr = "expFnr";
+        when(restTemplateMock.exchange(urlCaptor.capture(), httpMethodCaptor.capture(), httpEntityCaptor.capture(), eq(AfpHistorikkDto.class)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
+
+        consumer.getAfpHistorikkForPerson(expectedFnr);
+
+        assertThat(httpMethodCaptor.getValue(), is(HttpMethod.GET));
+        assertThat(urlCaptor.getValue(), is(AFP_HISTORIKK_URL));
+        assertThat("Request should contain header pid", httpEntityCaptor.getValue().getHeaders().containsKey("pid"), is(true));
+        assertThat(Objects.requireNonNull(httpEntityCaptor.getValue().getHeaders().get("pid")).get(0), is(expectedFnr));
+    }
+
+    @Test
+    void should_get_Uforehistorikk_when_getUforeHistorikkForPerson() {
+        var historikkDto = new UforeHistorikkDto();
+        var uforeperiode = new UforeperiodeDto();
+        uforeperiode.setUforegrad(50);
+        historikkDto.setUforeperiodeListe(singletonList(uforeperiode));
+        ResponseEntity<UforeHistorikkDto> entity = new ResponseEntity<>(historikkDto, HttpStatus.OK);
+        when(restTemplateMock.exchange(eq(UFOREHISTORIKK_URL), any(), any(), eq(UforeHistorikkDto.class))).thenReturn(entity);
+
+        UforeHistorikk historikk = consumer.getUforeHistorikkForPerson("");
+
         List<Uforeperiode> perioder = historikk.getUforeperioder();
         assertEquals(1, perioder.size());
-        Uforeperiode periode = perioder.get(0);
-        assertEquals(100, periode.getUforegrad());
-        assertEquals(UforeTypeCode.UFORE, periode.getUforetype());
-        assertEquals(LocalDate.of(2019, 10, 1), periode.getFomDate());
-        assertFalse(periode.hasTomDate());
-        assertNull(periode.getTomDate());
+        assertEquals(50, perioder.get(0).getUforegrad());
     }
 
     @Test
-    @Order(2)
-    void getAfpHistorikkForPerson_returns_null_when_noData() throws InterruptedException {
-        prepare(emptyResponse());
+    void should_add_fnr_as_headerparam_in_GET_when_getUforehistorikkForPerson() {
+        String expectedFnr = "expFnr";
+        when(restTemplateMock.exchange(urlCaptor.capture(), httpMethodCaptor.capture(), httpEntityCaptor.capture(), eq(UforeHistorikkDto.class)))
+                .thenReturn(new ResponseEntity<>(HttpStatus.OK));
 
-        AfpHistorikk historikk = consumer.getAfpHistorikkForPerson("fnr");
+        consumer.getUforeHistorikkForPerson(expectedFnr);
 
-        RecordedRequest request = takeRequest();
-        HttpUrl requestUrl = request.getRequestUrl();
-        assertNotNull(requestUrl);
-        assertEquals("GET", request.getMethod());
-        assertEquals("Bearer token", request.getHeader(HttpHeaders.AUTHORIZATION));
-        assertEquals("fnr", request.getHeader("pid"));
-        assertNull(historikk);
+        assertThat(httpMethodCaptor.getValue(), is(HttpMethod.GET));
+        assertThat(urlCaptor.getValue(), is(UFOREHISTORIKK_URL));
+        assertThat("Request should contain header pid", httpEntityCaptor.getValue().getHeaders().containsKey("pid"), is(true));
+        assertThat(Objects.requireNonNull(httpEntityCaptor.getValue().getHeaders().get("pid")).get(0), is(expectedFnr));
     }
 
     @Test
-    @Order(3)
-    void ping_ok() throws InterruptedException {
-        prepare(pingResponse());
-
-        consumer.ping();
-
-        RecordedRequest request = takeRequest();
-        HttpUrl requestUrl = request.getRequestUrl();
-        assertNotNull(requestUrl);
-        assertEquals("GET", request.getMethod());
-        assertEquals("Bearer token", request.getHeader(HttpHeaders.AUTHORIZATION));
-    }
-
-    @Order(4)
-    @Test
-    void getUforeHistorikkForPerson_throws_FailedCallingExternalServiceException_when_invalidPid() {
-        prepare(invalidPidResponse());
+    void should_throw_FailedCallingExternalServiceException_when_401_from_getAfphistorikkForPerson() {
+        when(restTemplateMock.exchange(eq(AFP_HISTORIKK_URL), any(), any(), eq(AfpHistorikkDto.class)))
+                .thenThrow(new RestClientResponseException("", HttpStatus.UNAUTHORIZED.value(), "", null, null, null));
 
         var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
-                () -> consumer.getUforeHistorikkForPerson("fnr"));
+                () -> consumer.getAfpHistorikkForPerson(""));
 
-        assertThat(thrown.getMessage(),
-                is(EXPECTED_UFORE_HISTORIKK_ERROR_MESSAGE + " Received 400 BAD REQUEST"));
+        assertThat(thrown.getMessage(), is("Error when calling the external service " + EXPECTED_AFP_HISTORIKK_IDENTIFIER + " in " + PEN + ". Received 401 UNAUTHORIZED"));
     }
 
     @Test
-    @Order(5)
-    void getUforeHistorikkForPerson_throws_FailedCallingExternalServiceException_when_expiredToken() {
-        prepare(expiredTokenResponse());
+    void should_throw_FailedCallingExternalServiceException_when_500_from_getUttaksgradForVedtak() {
+        when(restTemplateMock.exchange(eq(AFP_HISTORIKK_URL), any(), any(), eq(AfpHistorikkDto.class)))
+                .thenThrow(new RestClientResponseException("", HttpStatus.INTERNAL_SERVER_ERROR.value(), "", null, null, null));
 
         var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
-                () -> consumer.getUforeHistorikkForPerson("fnr"));
+                () -> consumer.getAfpHistorikkForPerson(""));
 
-        assertThat(thrown.getMessage(),
-                is(EXPECTED_UFORE_HISTORIKK_ERROR_MESSAGE +
-                        " An error occurred in the provider, received 500 INTERNAL SERVER ERROR"));
+        assertThat(thrown.getMessage(), is("Error when calling the external service " + EXPECTED_AFP_HISTORIKK_IDENTIFIER + " in " + PEN
+                + ". An error occurred in the provider, received 500 INTERNAL SERVER ERROR"));
     }
 
     @Test
-    @Order(6)
-    void getUforeHistorikkForPerson_throws_FailedCallingExternalServiceException_when_invalidToken() {
-        prepare(invalidTokenResponse());
+    void should_throw_FailedCallingExternalServiceException_when_400_from_getUttaksgradForVedtak() {
+        when(restTemplateMock.exchange(eq(AFP_HISTORIKK_URL), any(), any(), eq(AfpHistorikkDto.class)))
+                .thenThrow(new RestClientResponseException("", HttpStatus.BAD_REQUEST.value(), "", null, null, null));
 
         var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
-                () -> consumer.getUforeHistorikkForPerson("fnr"));
+                () -> consumer.getAfpHistorikkForPerson(""));
 
-        assertThat(thrown.getMessage(),
-                is(EXPECTED_UFORE_HISTORIKK_ERROR_MESSAGE +
-                        " An error occurred in the provider, received 500 INTERNAL SERVER ERROR"));
+        assertThat(thrown.getMessage(), is("Error when calling the external service " + EXPECTED_AFP_HISTORIKK_IDENTIFIER + " in " + PEN + ". Received 400 BAD REQUEST"));
     }
 
-    @Order(7)
     @Test
-    void getAfpHistorikkForPerson_throws_FailedCallingExternalServiceException_when_invalidPid() {
-        prepare(invalidPidResponse());
+    void should_throw_FailedCallingExternalServiceException_when_RestClientException_from_getUttaksgradForVedtak() {
+        when(restTemplateMock.exchange(eq(AFP_HISTORIKK_URL), any(), any(), eq(AfpHistorikkDto.class)))
+                .thenThrow(new RestClientException("oops"));
 
         var thrown = assertThrows(
                 FailedCallingExternalServiceException.class,
-                () -> consumer.getAfpHistorikkForPerson("fnr"));
+                () -> consumer.getAfpHistorikkForPerson(""));
+
+        assertThat(thrown.getMessage(), is("Error when calling the external service " + EXPECTED_AFP_HISTORIKK_IDENTIFIER + " in " + PEN + ". Failed to access service"));
+    }
+
+    @Test
+    void should_throw_FailedCallingExternalServiceException_when_401_from_getAlderSakUttaksgradhistorikkForPerson() {
+        when(restTemplateMock.exchange(eq(UFOREHISTORIKK_URL), any(), any(), eq(UforeHistorikkDto.class)))
+                .thenThrow(new RestClientResponseException("", HttpStatus.UNAUTHORIZED.value(), "", null, null, null));
+
+        var thrown = assertThrows(
+                FailedCallingExternalServiceException.class,
+                () -> consumer.getUforeHistorikkForPerson(""));
+
+        assertThat(thrown.getMessage(), is("Error when calling the external service " + EXPECTED_UFOREHISTORIKK_IDENTIFIER + " in " + PEN + ". Received 401 UNAUTHORIZED"));
+    }
+
+    @Test
+    void should_throw_FailedCallingExternalServiceException_when_500_from_getAlderSakUttaksgradhistorikkForPerson() {
+        when(restTemplateMock.exchange(eq(UFOREHISTORIKK_URL), any(), any(), eq(UforeHistorikkDto.class)))
+                .thenThrow(new RestClientResponseException("", HttpStatus.INTERNAL_SERVER_ERROR.value(), "", null, null, null));
+
+        var thrown = assertThrows(
+                FailedCallingExternalServiceException.class,
+                () -> consumer.getUforeHistorikkForPerson(""));
+
+        assertThat(thrown.getMessage(), is("Error when calling the external service " + EXPECTED_UFOREHISTORIKK_IDENTIFIER + " in " + PEN
+                + ". An error occurred in the provider, received 500 INTERNAL SERVER ERROR"));
+    }
+
+    @Test
+    void should_throw_FailedCallingExternalServiceException_when_400_from_getAlderSakUttaksgradhistorikkForPerson() {
+        when(restTemplateMock.exchange(eq(UFOREHISTORIKK_URL), any(), any(), eq(UforeHistorikkDto.class)))
+                .thenThrow(new RestClientResponseException("", HttpStatus.BAD_REQUEST.value(), "", null, null, null));
+
+        var thrown = assertThrows(
+                FailedCallingExternalServiceException.class,
+                () -> consumer.getUforeHistorikkForPerson(""));
+
+        assertThat(thrown.getMessage(), is("Error when calling the external service " + EXPECTED_UFOREHISTORIKK_IDENTIFIER + " in " + PEN + ". Received 400 BAD REQUEST"));
+    }
+
+    @Test
+    void should_throw_FailedCallingExternalServiceException_when_RestClientException_from_getAlderSakUttaksgradhistorikkForPerson() {
+        when(restTemplateMock.exchange(eq(UFOREHISTORIKK_URL), any(), any(), eq(UforeHistorikkDto.class)))
+                .thenThrow(new RestClientException("oops"));
+
+        var thrown = assertThrows(
+                FailedCallingExternalServiceException.class,
+                () -> consumer.getUforeHistorikkForPerson(""));
 
         assertThat(thrown.getMessage(),
-                is(EXPECTED_AFP_HISTORIKK_ERROR_MESSAGE + " Received 400 BAD REQUEST"));
-    }
-
-    private static MockResponse uforeHistorikkResponse() {
-        return jsonResponse()
-                .setBody("{\n" +
-                        "    \"garantigradYrke\": null,\n" +
-                        "    \"reaktiviseringFomDato\": null,\n" +
-                        "    \"uforeperiodeListe\": [\n" +
-                        "        {\n" +
-                        "            \"uforegrad\": 100,\n" +
-                        "            \"uforeperiodeId\": 500326589,\n" +
-                        "            \"uforetidspunkt\": 1569880800000,\n" +
-                        "            \"virk\": 1580511600000,\n" +
-                        "            \"uforetype\": \"UFORE\",\n" +
-                        "            \"fppGarantiKode\": null,\n" +
-                        "            \"redusertAntFppAr\": 0,\n" +
-                        "            \"fpp\": 0.0,\n" +
-                        "            \"uforetidspunktTom\": null,\n" +
-                        "            \"fppGaranti\": 0.0,\n" +
-                        "            \"fpp_omregnet\": 0.0,\n" +
-                        "            \"spt_pa_f92\": 0,\n" +
-                        "            \"spt_pa_e91\": 0,\n" +
-                        "            \"opt_pa_f92\": 0,\n" +
-                        "            \"opt_pa_e91\": 0,\n" +
-                        "            \"ypt_pa_f92\": 0,\n" +
-                        "            \"ypt_pa_e91\": 0,\n" +
-                        "            \"spt_eos\": 0.0,\n" +
-                        "            \"spt_pa_e91_eos\": 0,\n" +
-                        "            \"spt_pa_f92_eos\": 0,\n" +
-                        "            \"spt\": 0.0,\n" +
-                        "            \"opt\": 0.0,\n" +
-                        "            \"ypt\": 0.0,\n" +
-                        "            \"paa\": 0.0,\n" +
-                        "            \"ufgFom\": 1569880800000,\n" +
-                        "            \"ufgTom\": null,\n" +
-                        "            \"proRataNevner\": null,\n" +
-                        "            \"proRataTeller\": null,\n" +
-                        "            \"proRataBeregningType\": null,\n" +
-                        "            \"redusertAntFppArProRata\": null,\n" +
-                        "            \"sptProRata\": null,\n" +
-                        "            \"fodselsArYngsteBarn\": 0\n" +
-                        "        }\n" +
-                        "    ],\n" +
-                        "    \"lonnstilskuddTomDato\": null,\n" +
-                        "    \"frysHvilPensjTomDato\": null,\n" +
-                        "    \"forlengelseFrysTomDato\": null,\n" +
-                        "    \"uforehistorikkId\": 557901588,\n" +
-                        "    \"garantigrad\": null,\n" +
-                        "    \"lonnstilskuddFomDato\": null,\n" +
-                        "    \"frysHvilPensjFomDato\": null,\n" +
-                        "    \"reaktiviseringTomDato\": null,\n" +
-                        "    \"ungUfor\": false,\n" +
-                        "    \"forlengelseFrysFomDato\": null\n" +
-                        "}");
-    }
-
-    private static MockResponse invalidPidResponse() {
-        return jsonResponse(HttpStatus.BAD_REQUEST)
-                .setBody("{\n" +
-                        "    \"feil\": \"SimplePidParamConverter: Invalid pid as input to REST service\"\n" +
-                        "}");
-    }
-
-    private static MockResponse expiredTokenResponse() {
-        return new MockResponse()
-                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_HTML_VALUE)
-                .setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR.value())
-                .setBody("<!doctype html>\n" +
-                        "<html lang=\"en\">\n" +
-                        "<head>\n" +
-                        "  <title>HTTP Status 500 – Internal Server Error</title>\n" +
-                        "</head>\n" +
-                        "<body>\n" +
-                        "  <h1>HTTP Status 500 – Internal Server Error</h1>\n" +
-                        "  <p><b>Type</b> Exception Report</p>\n" +
-                        "  <p><b>Message</b> JWT token is not valid: JWT\n" +
-                        "    (claims-&gt;{&quot;sub&quot;:&quot;srvpensjon&quot;,&quot;aud&quot;:[&quot;srvpensjon&quot;,&quot;preprod.local&quot;],&quot;ver&quot;:&quot;1.0&quot;,&quot;nbf&quot;:1612199803,&quot;azp&quot;:&quot;srvpensjon&quot;,&quot;identType&quot;:&quot;Systemressurs&quot;,&quot;auth_time&quot;:1612199803,&quot;iss&quot;:&quot;https:\\&#47;\\&#47;security-token-service.nais.preprod.local&quot;,&quot;exp&quot;:1612203403,&quot;iat&quot;:1612199803,&quot;jti&quot;:&quot;b6307b4b-db49-4b35-86f7-4d1b8c83d63e&quot;})\n" +
-                        "    rejected due to invalid claims. Additional details: [[1] The JWT is no longer valid - the evaluation time\n" +
-                        "    NumericDate{1612215217 -&gt; Feb 1, 2021 10:33:37 PM CET} is on or after the Expiration Time\n" +
-                        "    (exp=NumericDate{1612203403 -&gt; Feb 1, 2021 7:16:43 PM CET}) claim value (even when providing 20 seconds of\n" +
-                        "    leeway to account for clock skew).]</p>\n" +
-                        "  <p><b>Description</b> The server encountered an unexpected condition that prevented it from fulfilling the request.\n" +
-                        "  </p>\n" +
-                        "</body>\n" +
-                        "</html>");
-    }
-
-    private static MockResponse invalidTokenResponse() {
-        return new MockResponse()
-                .addHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_HTML_VALUE)
-                .setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR.value())
-                .setBody("<!doctype html>\n" +
-                        "<html lang=\"en\">\n" +
-                        "<body>\n" +
-                        "  <h1>HTTP Status 500 – Internal Server Error</h1>\n" +
-                        "  <p><b>Type</b> Exception Report</p>\n" +
-                        "  <p><b>Message</b> JWT token is not valid: JWT rejected due to invalid signature. Additional details: [[9] Invalid\n" +
-                        "    JWS Signature:\n" +
-                        "    JsonWebSignature{&quot;kid&quot;:&quot;758677f4-88bb-4400-a0d0-e7c8a8325037&quot;,&quot;typ&quot;:&quot;JWT&quot;,&quot;alg&quot;:&quot;RS256&quot;}-&gt;eyJ...6vD]\n" +
-                        "  </p>\n" +
-                        "  <p><b>Description</b> The server encountered an unexpected condition that prevented it from fulfilling the request.\n" +
-                        "  </p>\n" +
-                        "</body>\n" +
-                        "</html>");
-    }
-
-    private static MockResponse pingResponse() {
-        return jsonResponse() // PEN responds with 'application/json' despite plaintext body
-                .setBody("Service online!");
-    }
-
-    private static MockResponse emptyResponse() {
-        return jsonResponse()
-                .setBody("");
+                is("Error when calling the external service " + EXPECTED_UFOREHISTORIKK_IDENTIFIER + " in " + PEN + ". Failed to access service"));
     }
 }

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/util/LocalDateFromEpochDeserializerTest.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/util/LocalDateFromEpochDeserializerTest.java
@@ -20,8 +20,8 @@ class LocalDateFromEpochDeserializerTest {
 
     @Test
     void deserialize_gets_localDate_from_epoch() throws IOException {
-        when(parser.readValueAs(Long.class)).thenReturn(1600000000000L);
+        when(parser.readValueAs(Long.class)).thenReturn(757378900000L);
         LocalDate date = new LocalDateTimeFromEpochDeserializer().deserialize(parser, null);
-        assertEquals(LocalDate.of(2020, 9, 13), date);
+        assertEquals(LocalDate.of(1994, 1, 1), date);
     }
 }


### PR DESCRIPTION
Bruker fast tidssone GMT+1 (norsk vintertid) ved konvertering fra "epoch" (millisekunder siden 1970-01-01T00:00:00Z) til dato, slik at man får samme dato uansett hvilken tidssone enhetstestene kjøres i.