### PR TITLE
Consumer base class + DST time zone

### DIFF
--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/consumer/pen/AuthorizedPenConsumer.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/consumer/pen/AuthorizedPenConsumer.java
@@ -1,0 +1,67 @@
+package no.nav.pensjon.selvbetjeningopptjening.consumer.pen;
+
+import no.nav.pensjon.selvbetjeningopptjening.auth.serviceusertoken.ServiceUserTokenGetter;
+import no.nav.pensjon.selvbetjeningopptjening.auth.serviceusertoken.StsException;
+import no.nav.pensjon.selvbetjeningopptjening.consumer.FailedCallingExternalServiceException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.util.function.BiFunction;
+
+import static java.util.Objects.requireNonNull;
+import static no.nav.pensjon.selvbetjeningopptjening.util.Constants.PEN;
+
+public abstract class AuthorizedPenConsumer {
+
+    private static final String AUTH_TYPE = "Bearer";
+    private final ServiceUserTokenGetter tokenGetter;
+    private final Log log = LogFactory.getLog(getClass());
+
+    public AuthorizedPenConsumer(ServiceUserTokenGetter tokenGetter) {
+        this.tokenGetter = requireNonNull(tokenGetter);
+    }
+
+    protected <T> T getObject(BiFunction<String, String, T> getter, String argument, String serviceName) {
+        try {
+            return getter.apply(argument, getAuthHeaderValue());
+        } catch (StsException e) {
+            log.error(String.format("STS error in %s: %s", serviceName, e.getMessage()), e);
+            throw handle(e, serviceName);
+        } catch (WebClientResponseException e) {
+            throw handle(e, serviceName);
+        } catch (RuntimeException e) { // e.g. when connection broken
+            throw handle(e, serviceName);
+        }
+    }
+
+    private String getAuthHeaderValue() throws StsException {
+        return AUTH_TYPE + " " + tokenGetter.getServiceUserToken().getAccessToken();
+    }
+
+    private static FailedCallingExternalServiceException handle(WebClientResponseException e, String serviceIdentifier) {
+        if (e.getRawStatusCode() == HttpStatus.UNAUTHORIZED.value()) {
+            return new FailedCallingExternalServiceException(PEN, serviceIdentifier, "Received 401 UNAUTHORIZED", e);
+        }
+
+        if (e.getRawStatusCode() == HttpStatus.INTERNAL_SERVER_ERROR.value()) {
+            return new FailedCallingExternalServiceException(PEN, serviceIdentifier, "An error occurred in the provider, received 500 INTERNAL SERVER ERROR", e);
+        }
+
+        if (e.getRawStatusCode() == HttpStatus.BAD_REQUEST.value()) {
+            return new FailedCallingExternalServiceException(PEN, serviceIdentifier, "Received 400 BAD REQUEST", e);
+        }
+
+        return new FailedCallingExternalServiceException(PEN, serviceIdentifier, "An error occurred in the consumer", e);
+    }
+
+    private static FailedCallingExternalServiceException handle(StsException e, String service) {
+        String cause = "Failed to acquire token for accessing " + service;
+        return new FailedCallingExternalServiceException(PEN, service, cause, e);
+    }
+
+    private static FailedCallingExternalServiceException handle(RuntimeException e, String service) {
+        return new FailedCallingExternalServiceException(PEN, service, "Failed to call service", e);
+    }
+}

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/consumer/person/PersonConsumer.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/consumer/person/PersonConsumer.java
@@ -1,8 +1,7 @@
 package no.nav.pensjon.selvbetjeningopptjening.consumer.person;
 
 import no.nav.pensjon.selvbetjeningopptjening.auth.serviceusertoken.ServiceUserTokenGetter;
-import no.nav.pensjon.selvbetjeningopptjening.auth.serviceusertoken.StsException;
-import no.nav.pensjon.selvbetjeningopptjening.consumer.FailedCallingExternalServiceException;
+import no.nav.pensjon.selvbetjeningopptjening.consumer.pen.AuthorizedPenConsumer;
 import no.nav.pensjon.selvbetjeningopptjening.health.PingInfo;
 import no.nav.pensjon.selvbetjeningopptjening.health.Pingable;
 import no.nav.pensjon.selvbetjeningopptjening.model.AfpHistorikkDto;
@@ -11,140 +10,107 @@ import no.nav.pensjon.selvbetjeningopptjening.opptjening.AfpHistorikk;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.UforeHistorikk;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.mapping.AfpHistorikkMapper;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.mapping.UforeHistorikkMapper;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import static java.util.Objects.requireNonNull;
 import static no.nav.pensjon.selvbetjeningopptjening.util.Constants.PEN;
 
 @Component
-public class PersonConsumer implements Pingable {
+public class PersonConsumer extends AuthorizedPenConsumer implements Pingable {
 
+    private static final String ENDPOINT_PATH = "person";
+    private static final String SERVICE_DESCRIPTION = PEN + " " + ENDPOINT_PATH;
     private static final String AFP_HISTORIKK_SERVICE = "PROPEN2602 getAfphistorikkForPerson";
     private static final String UFORE_HISTORIKK_SERVICE = "PROPEN2603 getUforehistorikkForPerson";
-    private static final String PING_SERVICE = "PEN person ping";
-    private static final String ENDPOINT_PATH = "/person";
-    private static final String AUTH_TYPE = "Bearer";
-    private final Log log = LogFactory.getLog(getClass());
-    private final String endpoint;
+    private static final String AFP_HISTORIKK_RESOURCE = "afphistorikk";
+    private static final String UFORE_HISTORIKK_RESOURCE = "uforehistorikk";
+    private static final String PING_RESOURCE = "ping";
     private final WebClient webClient;
-    private final ServiceUserTokenGetter tokenGetter;
+    private final String endpoint;
 
     public PersonConsumer(@Qualifier("epoch-support") WebClient webClient,
                           @Value("${pen.endpoint.url}") String endpoint,
                           ServiceUserTokenGetter tokenGetter) {
+        super(tokenGetter);
         this.webClient = requireNonNull(webClient);
         this.endpoint = requireNonNull(endpoint);
-        this.tokenGetter = requireNonNull(tokenGetter);
     }
 
     public AfpHistorikk getAfpHistorikkForPerson(String fnr) {
-        try {
-            var historikk = webClient
-                    .get()
-                    .uri(endpoint + ENDPOINT_PATH + "/afphistorikk")
-                    .header(HttpHeaders.AUTHORIZATION, getAuthHeaderValue())
-                    .header(PersonHttpHeaders.PID, fnr)
-                    .retrieve()
-                    .bodyToMono(AfpHistorikkDto.class)
-                    .block();
-
-            return AfpHistorikkMapper.fromDto(historikk);
-        } catch (StsException e) {
-            log.error(String.format("STS error in %s: %s", AFP_HISTORIKK_SERVICE, e.getMessage()), e);
-            throw handle(e, AFP_HISTORIKK_SERVICE);
-        } catch (WebClientResponseException e) {
-            throw handle(e, AFP_HISTORIKK_SERVICE);
-        } catch (RuntimeException e) { // e.g. when connection broken
-            throw handle(e, AFP_HISTORIKK_SERVICE);
-        }
+        return getObject(this::getAfpHistorikk, fnr, AFP_HISTORIKK_SERVICE);
     }
 
     public UforeHistorikk getUforeHistorikkForPerson(String fnr) {
-        try {
-            var historikk = webClient
-                    .get()
-                    .uri(endpoint + ENDPOINT_PATH + "/uforehistorikk")
-                    .header(HttpHeaders.AUTHORIZATION, getAuthHeaderValue())
-                    .header(PersonHttpHeaders.PID, fnr)
-                    .retrieve()
-                    .bodyToMono(UforeHistorikkDto.class)
-                    .block();
-
-            return UforeHistorikkMapper.fromDto(historikk);
-        } catch (StsException e) {
-            log.error(String.format("STS error in %s: %s", UFORE_HISTORIKK_SERVICE, e.getMessage()), e);
-            throw handle(e, UFORE_HISTORIKK_SERVICE);
-        } catch (WebClientResponseException e) {
-            throw handle(e, UFORE_HISTORIKK_SERVICE);
-        } catch (RuntimeException e) { // e.g. when connection broken
-            throw handle(e, UFORE_HISTORIKK_SERVICE);
-        }
+        return getObject(this::getUforeHistorikk, fnr, UFORE_HISTORIKK_SERVICE);
     }
 
     @Override
     public void ping() {
-        try {
-            webClient
-                    .get()
-                    .uri(pingUri())
-                    .header(HttpHeaders.AUTHORIZATION, getAuthHeaderValue())
-                    .retrieve()
-                    .toBodilessEntity()
-                    .block();
-        } catch (StsException e) {
-            log.error(String.format("STS error in %s: %s", PING_SERVICE, e.getMessage()), e);
-            throw handle(e, PING_SERVICE);
-        } catch (WebClientResponseException e) {
-            throw handle(e, PING_SERVICE);
-        } catch (RuntimeException e) { // e.g. when connection broken
-            throw handle(e, PING_SERVICE);
-        }
+        getObject(this::ping, "pong", SERVICE_DESCRIPTION + " " + PING_RESOURCE);
     }
 
     @Override
     public PingInfo getPingInfo() {
-        return new PingInfo("REST", "PEN person", pingUri());
+        return new PingInfo("REST", SERVICE_DESCRIPTION, pingUri());
+    }
+
+    private AfpHistorikk getAfpHistorikk(String fnr, String authHeaderValue) {
+        AfpHistorikkDto dto = getAfpHistorikkDto(fnr, authHeaderValue);
+        return AfpHistorikkMapper.fromDto(dto);
+    }
+
+    private AfpHistorikkDto getAfpHistorikkDto(String fnr, String authHeaderValue) {
+        return webClient
+                    .get()
+                    .uri(path(AFP_HISTORIKK_RESOURCE))
+                    .header(HttpHeaders.AUTHORIZATION, authHeaderValue)
+                    .header(PersonHttpHeaders.PID, fnr)
+                    .retrieve()
+                    .bodyToMono(AfpHistorikkDto.class)
+                    .block();
+    }
+
+    private UforeHistorikk getUforeHistorikk(String fnr, String authHeaderValue) {
+        UforeHistorikkDto dto = getUforeHistorikkDto(fnr, authHeaderValue);
+        return UforeHistorikkMapper.fromDto(dto);
+    }
+
+    private UforeHistorikkDto getUforeHistorikkDto(String fnr, String authHeaderValue) {
+        return webClient
+                .get()
+                .uri(path(UFORE_HISTORIKK_RESOURCE))
+                .header(HttpHeaders.AUTHORIZATION, authHeaderValue)
+                .header(PersonHttpHeaders.PID, fnr)
+                .retrieve()
+                .bodyToMono(UforeHistorikkDto.class)
+                .block();
+    }
+
+    private String ping(String defaultResponse, String authHeaderValue) {
+        webClient
+                .get()
+                .uri(pingUri())
+                .header(HttpHeaders.AUTHORIZATION, authHeaderValue)
+                .retrieve()
+                .toBodilessEntity()
+                .block();
+
+        return defaultResponse;
     }
 
     private String pingUri() {
-        return UriComponentsBuilder.fromHttpUrl(endpoint).path(ENDPOINT_PATH + "/ping").toUriString();
+        return path(PING_RESOURCE);
     }
 
-    private String getAuthHeaderValue() throws StsException {
-        return AUTH_TYPE + " " + tokenGetter.getServiceUserToken().getAccessToken();
-    }
-
-    private static FailedCallingExternalServiceException handle(WebClientResponseException e, String serviceIdentifier) {
-        if (e.getRawStatusCode() == HttpStatus.UNAUTHORIZED.value()) {
-            return new FailedCallingExternalServiceException(PEN, serviceIdentifier, "Received 401 UNAUTHORIZED", e);
-        }
-
-        if (e.getRawStatusCode() == HttpStatus.INTERNAL_SERVER_ERROR.value()) {
-            return new FailedCallingExternalServiceException(PEN, serviceIdentifier, "An error occurred in the provider, received 500 INTERNAL SERVER ERROR", e);
-        }
-
-        if (e.getRawStatusCode() == HttpStatus.BAD_REQUEST.value()) {
-            return new FailedCallingExternalServiceException(PEN, serviceIdentifier, "Received 400 BAD REQUEST", e);
-        }
-
-        return new FailedCallingExternalServiceException(PEN, serviceIdentifier, "An error occurred in the consumer", e);
-    }
-
-    private static FailedCallingExternalServiceException handle(StsException e, String service) {
-        String cause = "Failed to acquire token for accessing " + service;
-        return new FailedCallingExternalServiceException(PEN, service, cause, e);
-    }
-
-    private static FailedCallingExternalServiceException handle(RuntimeException e, String service) {
-        return new FailedCallingExternalServiceException(PEN, service, "Failed to call service", e);
+    private String path(String end) {
+        return UriComponentsBuilder.fromHttpUrl(endpoint)
+                .path(ENDPOINT_PATH)
+                .path(end)
+                .toUriString();
     }
 }

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/util/LocalDateTimeFromEpochDeserializer.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/util/LocalDateTimeFromEpochDeserializer.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 
 public class LocalDateTimeFromEpochDeserializer extends StdDeserializer<LocalDate> {
 
-    private static final String TIME_ZONE = "UTC+1"; // Norway winter time
+    private static final String TIME_ZONE = "UTC+2"; // Norway daylight saving time
 
     public LocalDateTimeFromEpochDeserializer() {
         super(LocalDate.class);


### PR DESCRIPTION
Pga. mye duplisert feilhåndteringskode i Consumer-klassene har jeg laget en baseklasse for dette.
Man oppnår også å skille ut STS-aksessen (for å hente token) fra "kjerne"-funksjonene i konsumenten.

Har også endret tidssone til norsk sommertid (UTC+2) i konverteringen av epoch-verdier fra PEN/POPP til datoverdier. Dette fordi datoer registrert mens det er norsk sommertid blir i Zulu-tidssonen til kl 22 dagen før, dvs. man må legge til 2 timer for å få riktig "norsk" dato.