### PR TITLE
PL-3850 Audit-log on-behalf access

### DIFF
--- a/nais/nais-dev.yml
+++ b/nais/nais-dev.yml
@@ -34,12 +34,17 @@ spec:
       value: q2
     - name: AZURE_APP_REDIRECT_URI
       value: https://pensjon-selvbetjening-opptjening-frontend.dev.adeo.no/pensjon/opptjening/oauth2/internal/callback
+    - name: AUDIT_LOG_OUTPUT
+      value: SYSLOG
   envFrom:
     - configmap: loginservice-idporten
   azure:
     application:
       enabled: true
       tenant: nav.no
+      claims:
+        extra:
+          - NAVident
       replyURLs:
         - https://pensjon-selvbetjening-opptjening-frontend.dev.adeo.no/pensjon/opptjening/oauth2/internal/callback
         - http://localhost:8080/oauth2/internal/callback

--- a/nais/nais-prod.yml
+++ b/nais/nais-prod.yml
@@ -45,6 +45,8 @@ spec:
       value: p
     - name: AZURE_APP_REDIRECT_URI
       value: https://pensjon-selvbetjening-opptjening-frontend.intern.nav.no/pensjon/opptjening/oauth2/internal/callback
+    - name: AUDIT_LOG_OUTPUT
+      value: SYSLOG
   envFrom:
     - configmap: loginservice-idporten
   azure:

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,27 @@
         </dependency>
 
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+        </dependency>
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>6.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.30</version>
+        </dependency>
+        <dependency>
+            <groupId>com.papertrailapp</groupId>
+            <artifactId>logback-syslog4j</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/audit/CefEntry.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/audit/CefEntry.java
@@ -1,0 +1,70 @@
+package no.nav.pensjon.selvbetjeningopptjening.audit;
+
+import org.slf4j.event.Level;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.joining;
+
+/**
+ * CEF = ArcSight Common Event Format
+ * Note that no character escaping is performed here, since the logged info does not require this.
+ */
+public class CefEntry {
+
+    private static final int CEF_VERSION = 0;
+    private static final String PREAMBLE = "CEF:";
+    private static final String SEPARATOR = "|";
+    private static final String DEVICE_VENDOR = "pensjon-selvbetjening";
+    private static final String DEVICE_PRODUCT = "pensjon-selvbetjening-opptjening";
+    private static final String DEVICE_VERSION = "1.0";
+    private final long timestamp;
+    private final Level level;
+    private final String deviceEventClassId;
+    private final String name;
+    private final String deviceAction;
+    private final String sourceUserId;
+    private final String destinationUserId;
+
+    public CefEntry(long timestamp,
+                    Level level,
+                    String deviceEventClassId,
+                    String name,
+                    String deviceAction,
+                    String sourceUserId,
+                    String destinationUserId) {
+        this.timestamp = timestamp;
+        this.level = level;
+        this.deviceEventClassId = deviceEventClassId;
+        this.name = name;
+        this.deviceAction = deviceAction;
+        this.sourceUserId = sourceUserId;
+        this.destinationUserId = destinationUserId;
+    }
+
+    public String format() {
+        List<String> elements = List.of(
+                PREAMBLE + CEF_VERSION,
+                DEVICE_VENDOR,
+                DEVICE_PRODUCT,
+                DEVICE_VERSION,
+                deviceEventClassId,
+                name,
+                severity(),
+                extension());
+
+        return String.join(SEPARATOR, elements);
+    }
+
+    private String severity() {
+        return level == Level.INFO ? "INFO" : "WARN";
+    }
+
+    private String extension() {
+        return "end=" + timestamp +
+                " suid=" + sourceUserId +
+                " duid=" + destinationUserId +
+                " act=" + deviceAction;
+    }
+}

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningOnBehalfEndpoint.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningOnBehalfEndpoint.java
@@ -1,9 +1,10 @@
 package no.nav.pensjon.selvbetjeningopptjening.opptjening;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
-import no.nav.pensjon.selvbetjeningopptjening.config.OpptjeningFeature;
+import no.nav.pensjon.selvbetjeningopptjening.audit.CefEntry;
 import no.nav.pensjon.selvbetjeningopptjening.consumer.FailedCallingExternalServiceException;
-import no.nav.pensjon.selvbetjeningopptjening.consumer.uttaksgrad.UttaksgradGetter;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.dto.OpptjeningResponse;
 import no.nav.pensjon.selvbetjeningopptjening.security.LoginSecurityLevel;
 import no.nav.pensjon.selvbetjeningopptjening.security.group.GroupChecker;
@@ -13,6 +14,7 @@ import no.nav.pensjon.selvbetjeningopptjening.security.jwt.JwsValidator;
 import no.nav.security.token.support.core.api.Unprotected;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,17 +24,18 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
 import javax.servlet.http.HttpServletRequest;
+import java.time.ZonedDateTime;
 
 import static java.util.Objects.requireNonNull;
 import static no.nav.pensjon.selvbetjeningopptjening.security.masking.Masker.maskFnr;
-import static no.nav.pensjon.selvbetjeningopptjening.unleash.UnleashProvider.toggle;
 
 @RestController
 @RequestMapping("api")
 @Unprotected // not protected by token-service, but a custom protection is used (due to split ID token cookie)
 public class OpptjeningOnBehalfEndpoint {
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger AUDIT = LoggerFactory.getLogger("AUDIT_LOGGER");
+    private static final Logger LOG = LoggerFactory.getLogger(OpptjeningOnBehalfEndpoint.class);
     private final OpptjeningProvider provider;
     private final JwsValidator jwsValidator;
     private final GroupChecker groupChecker;
@@ -48,17 +51,17 @@ public class OpptjeningOnBehalfEndpoint {
     @GetMapping("/opptjeningonbehalf")
     public OpptjeningResponse getOpptjeningForFnr(HttpServletRequest request,
                                                   @RequestParam(value = "fnr") String fnr) {
-        log.info("Received on-behalf request for opptjening for fnr {}", maskFnr(fnr));
+        LOG.info("Received on-behalf request for opptjening for fnr {}", maskFnr(fnr));
 
         try {
             String idToken = SplitCookieAssembler.getCookieValue(request, CookieType.INTERNAL_USER_ID_TOKEN);
 
             if (StringUtils.isEmpty(idToken)) {
-                log.info("No JWT in request");
+                LOG.info("No JWT in request");
                 throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "No JWT");
             }
 
-            jwsValidator.validate(idToken);
+            Jws<Claims> claims = jwsValidator.validate(idToken);
             String accessToken = SplitCookieAssembler.getCookieValue(request, CookieType.INTERNAL_USER_ACCESS_TOKEN);
             var pid = new Pid(fnr, true);
 
@@ -66,15 +69,16 @@ public class OpptjeningOnBehalfEndpoint {
                 return forbidden();
             }
 
+            AUDIT.info(getAuditInfo(fnr, claims).format());
             return provider.calculateOpptjeningForFnr(pid, LoginSecurityLevel.INTERNAL);
         } catch (JwtException e) {
-            log.error("JwtException. Message: {}.", e.getMessage());
+            LOG.error("JwtException. Message: {}.", e.getMessage());
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, e.getMessage(), e);
         } catch (PidValidationException e) {
-            log.error("Invalid PID: {}. Message: {}.", maskFnr(fnr), e.getMessage());
+            LOG.error("Invalid PID: {}. Message: {}.", maskFnr(fnr), e.getMessage());
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
         } catch (FailedCallingExternalServiceException e) {
-            log.error("Failed calling external service. Message: {}.", e.getMessage());
+            LOG.error("Failed calling external service. Message: {}.", e.getMessage());
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage(), e);
         }
     }
@@ -83,9 +87,20 @@ public class OpptjeningOnBehalfEndpoint {
         return groupChecker.isUserAuthorized(pid, accessToken);
     }
 
+    private CefEntry getAuditInfo(String fnr, Jws<Claims> claims) {
+        return new CefEntry(
+                ZonedDateTime.now().toInstant().toEpochMilli(),
+                Level.INFO,
+                "audit:access",
+                "Datahenting paa vegne av",
+                "Internbruker henter pensjonsopptjeningsdata for innbygger",
+                (String) claims.getBody().get("NAVident"),
+                fnr);
+    }
+
     private OpptjeningResponse forbidden() {
         String message = "User is not allowed";
-        log.info(message);
+        LOG.info(message);
         throw new ResponseStatusException(HttpStatus.FORBIDDEN, message);
     }
 }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <property name="AUDIT_LOG_APPENDER" value="${AUDIT_LOG_OUTPUT:-CONSOLE}_AUDIT" />
+
+    <appender name="STDOUT_JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
+                <maxDepthPerThrowable>30</maxDepthPerThrowable>
+                <exclude>java\.util\.concurrent\..*</exclude>
+                <exclude>org\.apache\.tomcat\..*</exclude>
+                <exclude>org\.apache\.coyote\..*</exclude>
+                <exclude>org\.apache\.catalina\..*</exclude>
+                <exclude>org\.springframework\.web\..*</exclude>
+            </throwableConverter>
+        </encoder>
+    </appender>
+
+    <appender name="SYSLOG_AUDIT" class="com.papertrailapp.logback.Syslog4jAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%m%n%xEx</pattern>
+        </layout>
+
+        <syslogConfig class="org.productivity.java.syslog4j.impl.net.tcp.TCPNetSyslogConfig">
+            <host>audit.nais</host>
+            <port>6514</port>
+            <ident>pensjon-selvbetjening-opptjening</ident>
+            <maxMessageLength>128000</maxMessageLength>
+        </syslogConfig>
+    </appender>
+
+    <appender name="CONSOLE_AUDIT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>[%d, %-5p, %c:%L, %t] AUDIT - %mdc %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="AUDIT_LOGGER" level="INFO" additivity="false">
+        <appender-ref ref="${AUDIT_LOG_APPENDER}"/>
+    </logger>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT_JSON"/>
+    </root>
+</configuration>

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/audit/CefEntryTest.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/audit/CefEntryTest.java
@@ -1,0 +1,26 @@
+package no.nav.pensjon.selvbetjeningopptjening.audit;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.event.Level;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CefEntryTest {
+
+    @Test
+    void format_returns_info_formattedAccordingTo_cefSpec() {
+        var cefEntry = new CefEntry(
+                123456789L,
+                Level.INFO,
+                "audit:read",
+                "Hendelse",
+                "Noe blir gjort",
+                "X123456",
+                "01020345678");
+
+        String formattedInfo = cefEntry.format();
+
+        assertEquals("CEF:0|pensjon-selvbetjening|pensjon-selvbetjening-opptjening|1.0|audit:read|Hendelse|" +
+                "INFO|end=123456789 suid=X123456 duid=01020345678 act=Noe blir gjort", formattedInfo);
+    }
+}


### PR DESCRIPTION
Sporingslogging innebærer å sende info om hva en internbruker (f.eks. saksbehandler) ser på av data for en innbygger.
Infoen sendes til ArcSight i form av en CEF-formattert streng.
Se [NAIS audit logs](https://doc.nais.io/observability/logs/#audit-logs) og [Slack #tech-logg_analyse_og_datainnsikt](https://nav-it.slack.com/archives/C014576K5TQ) for detaljer.