### PR TITLE
PL-4902 Use GHCR as Docker image repository

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -3,7 +3,7 @@ name: "Deploy to development"
 on: workflow_dispatch
 
 env:
-  IMAGE: docker.pkg.github.com/${{ github.repository }}/pensjon-selvbetjening-opptjening-backend:${{ github.sha }}
+  IMAGE: ghcr.io/${{ github.repository }}/pensjon-selvbetjening-opptjening-backend:${{ github.sha }}
 
 jobs:
   deploy-to-dev:
@@ -31,13 +31,19 @@ jobs:
       - name: Build Docker image
         run: |
           docker build -t ${IMAGE} .
-      - name: Login to Github Package Registry
-        env:
-          DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "$DOCKER_PASSWORD" | docker login --username "$GITHUB_REPOSITORY" --password-stdin docker.pkg.github.com
+      - name: Log in to the container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push Docker image
-        run: "docker push ${IMAGE}"
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ env.IMAGE }}
       - name: Deploy to dev-fss
         uses: nais/deploy/actions/deploy@v1
         env:

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -19,5 +19,5 @@ jobs:
         env:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: prod-fss
-          IMAGE: docker.pkg.github.com/${{ github.repository }}/pensjon-selvbetjening-opptjening-backend:${{ github.event.inputs.version }}
+          IMAGE: ghcr.io/${{ github.repository }}/pensjon-selvbetjening-opptjening-backend:${{ github.event.inputs.version }}
           RESOURCE: .nais/prod-fss.yml


### PR DESCRIPTION
Bruker GitHub Container Registry (ghcr.io) istedenfor Docker hub (docker.pkg.github.com) som repository for Docker-image.