### PR TITLE
PL-5041: Not adding endring of type REGULERING unless lonnsveksregule…

### DIFF
--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/Beholdning.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/Beholdning.java
@@ -149,7 +149,9 @@ public class Beholdning implements Periode {
     }
 
     boolean hasLonnsvekstreguleringsbelop() {
-        return lonnsvekstregulering != null && lonnsvekstregulering.hasBelop();
+        return lonnsvekstregulering != null
+                && lonnsvekstregulering.hasBelop()
+                && lonnsvekstregulering.getReguleringsDato() != null;
     }
 
     public Inntektsopptjening getInntektsopptjening() {
@@ -249,7 +251,7 @@ public class Beholdning implements Periode {
         return grunnlagTypes.isEmpty() ? List.of(NO_GRUNNLAG) : grunnlagTypes;
     }
 
-    boolean isOmsorgGrunnlagForBeholdning(){
+    boolean isOmsorgGrunnlagForBeholdning() {
         return grunnlag == omsorgsopptjening.getBelop();
     }
 

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/EndringPensjonsbeholdningCalculator.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/EndringPensjonsbeholdningCalculator.java
@@ -204,7 +204,8 @@ public class EndringPensjonsbeholdningCalculator {
 
         double vedtakPensjonseringsbelop = 0D;
 
-        if (beholdning.hasLonnsvekstreguleringsbelop()) {
+        if (beholdning.hasLonnsvekstreguleringsbelop()
+                && beholdning.getLonnsvekstregulering().getReguleringsDato().isEqual(beholdning.getFomDato())) {
             double lonnsvekstreguleringsbelop = beholdning.getLonnsvekstreguleringsbelop();
             vedtakPensjonseringsbelop = lonnsvekstreguleringsbelop + lastBeholdningsbelop;
 

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/Lonnsvekstregulering.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/Lonnsvekstregulering.java
@@ -1,13 +1,17 @@
 package no.nav.pensjon.selvbetjeningopptjening.opptjening;
 
+import java.time.LocalDate;
+
 public class Lonnsvekstregulering {
 
     private final boolean hasBelop;
     private final double belop;
+    private final LocalDate reguleringsDato;
 
-    public Lonnsvekstregulering(Double belop) {
+    public Lonnsvekstregulering(Double belop, LocalDate reguleringsDato) {
         this.belop = belop == null ? 0D : belop;
         this.hasBelop = belop != null;
+        this.reguleringsDato = reguleringsDato;
     }
 
     public double getBelop() {
@@ -16,5 +20,9 @@ public class Lonnsvekstregulering {
 
     boolean hasBelop() {
         return hasBelop;
+    }
+
+    public LocalDate getReguleringsDato() {
+        return reguleringsDato;
     }
 }

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/mapping/BeholdningMapper.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/mapping/BeholdningMapper.java
@@ -46,7 +46,7 @@ public class BeholdningMapper {
     private static Lonnsvekstregulering fromDto(LonnsvekstreguleringDto dto) {
         return dto == null ? null
                 :
-                new Lonnsvekstregulering(dto.getReguleringsbelop());
+                new Lonnsvekstregulering(dto.getReguleringsbelop(), dto.getReguleringsDato());
     }
 
     private static Inntektsopptjening fromDto(InntektOpptjeningBelopDto dto) {


### PR DESCRIPTION
**Problemet:** På inneværende år i år-for-år-visningen vil det i perioden før regulering er gjort vises for enkelte brukere at regulering er lagt til beholdningen.

**Feilrettingen er implementert ut fra følgende forståelse av problemårsaken:** Problemet oppstår for brukere som har alderspensjonsvedtak med virkning 01.05 det aktuelle året. Da legger nemlig PEN til en ny beholdning med fomDato 01.05. Denne beholdningen får satt lønnsvekstreguleringsbeløp lik lønnsvekstreguleringsbeløpet fra fjoråret, noe som er feil for dette året. Det er POPP som setter denne verdien. Når "Din pensjonsopptjening" skal avgjøre om det finnes en beholdning som er opprettet knyttet til regulering, sjekker den om det finnes en beholdning med fomDato lik reguleringsdatoen, som alltid er 01.05. I tillegg sjekker den om denne beholdningen har satt en et lønnsvekstreguleringsbeløp. Hvis dette er tilfelle, legger den til en ny linje i endringslista som markeres som at beholdningen har økt tilsvarende lønnsvekstreguleringen. Beholdningen som PEN har opprettet i forbindelse med vedtak av alderspensjon fra 01.05 mistolkes dermed som en beholdning som skyldes regulering. Siden denne inneholder reguleringsbeløpet som gjelder for i fjor, blir dette feil, og i tillegg gir det inntrykk av at regulering har blitt gjort, når realiteten er at den ikke blir gjort før 01.05. Feilen forekommer altså kun for brukere som har aldersvedtak med virkning samme dato som reguleringsdatoen.

**Løsning som er implementert:** Når det skal sjekkes om en beholdning skyldes regulering legges det til en ekstra sjekk som sjekker at datoen for lønnsvekstreguleringen er den samme som fomDatoen for beholdningen. Hvis det er avvik, vet vi at lønnsvekstreguleringen gjelder for et annet år enn beholdningen, og beholdningen representerer ikke en faktisk regulering, men noe annet som tilfeldigvis skjer på samme dato.