### PR TITLE
Log expired jwt level as info with correct ExpiredJwtException

### DIFF
--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningOnBehalfEndpoint.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningOnBehalfEndpoint.java
@@ -1,6 +1,7 @@
 package no.nav.pensjon.selvbetjeningopptjening.opptjening;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
 import no.nav.pensjon.selvbetjeningopptjening.audit.CefEntry;
@@ -72,6 +73,9 @@ public class OpptjeningOnBehalfEndpoint {
 
             AUDIT.info(getAuditInfo(fnr, claims).format());
             return provider.calculateOpptjeningForFnr(pid, LoginSecurityLevel.INTERNAL);
+        } catch (ExpiredJwtException e) {
+            LOG.info("ExpiredJwtException. Message: {}.", e.getMessage());
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, e.getMessage(), e);
         } catch (JwtException e) {
             LOG.error("JwtException. Message: {}.", e.getMessage());
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, e.getMessage(), e);


### PR DESCRIPTION
Alle JwtException feilmeldinger i loggen er av typen "Expired token" vil derfor logge det mer direkte så vi ser det med en gang.
https://logs.adeo.no/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now%2Fw,to:now%2Fw))&_a=(columns:!(message,envclass,level,application,host),filters:!(),index:'96e648c0-980a-11e9-830a-e17bbd64b4db',interval:auto,query:(language:kuery,query:'application%20:%20%22pensjon-selvbetjening-opptjening-backend%22%20and%20envclass:%20%22p%22%20and%20%22JwtException*%22'),sort:!())
