### PR TITLE
Requestparam skal være pid istedenfor fnr

### DIFF
--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/consumer/CustomHttpHeaders.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/consumer/CustomHttpHeaders.java
@@ -5,7 +5,7 @@ import static no.nav.pensjon.selvbetjeningopptjening.util.Constants.NAV_CALL_ID;
 public final class CustomHttpHeaders {
 
     public static final String AKTOER_NUMMER = "aktorNr"; // aktørnummer
-    public static final String FNR = "fnr"; // fødselsnummer
+    public static final String FNR = "pid"; // fødselsnummer
     public static final String FOM = "fom"; // fra og med
     public static final String CALL_ID = NAV_CALL_ID;
     public static final String CONSUMER_ID = "Nav-Consumer-Id";

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningOnBehalfEndpoint.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningOnBehalfEndpoint.java
@@ -34,8 +34,8 @@ public class OpptjeningOnBehalfEndpoint {
     }
 
     @GetMapping("/opptjeningonbehalf")
-    public OpptjeningResponse getOpptjeningOnBehalfOf(@RequestParam(value = "fnr") String pidValue) {
-        log.info("Received on-behalf-of request for opptjening for fnr {}", maskFnr(pidValue));
+    public OpptjeningResponse getOpptjeningOnBehalfOf(@RequestParam(value = "pid") String pidValue) {
+        log.info("Received on-behalf-of request for opptjening for pid {}", maskFnr(pidValue));
 
         try {
             audit.info(getAuditInfo(pidValue, RequestContext.getNavIdent()).format());

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/usersession/internaluser/QueryParamNames.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/usersession/internaluser/QueryParamNames.java
@@ -2,7 +2,7 @@ package no.nav.pensjon.selvbetjeningopptjening.usersession.internaluser;
 
 public final class QueryParamNames {
 
-    public static final String PID = "fnr"; // PID = person-ID, fnr = fødselsnummer
+    public static final String PID = "pid"; // PID = person-ID, fnr = fødselsnummer
 
     private QueryParamNames() {
     }

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/mock/WebClientTest.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/mock/WebClientTest.java
@@ -18,7 +18,7 @@ import no.nav.pensjon.selvbetjeningopptjening.SelvbetjeningOpptjeningApplication
 
 @SpringBootTest
 @ContextConfiguration(classes = SelvbetjeningOpptjeningApplication.class)
-@TestPropertySource(properties = "fnr=dummy")
+@TestPropertySource(properties = "pid=dummy")
 @ActiveProfiles("test")
 public class WebClientTest {
 

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningOnBehalfEndpointTest.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningOnBehalfEndpointTest.java
@@ -44,7 +44,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class OpptjeningOnBehalfEndpointTest {
 
     private static final Pid PID = new Pid("04925398980");
-    private static final String URI = "/api/opptjeningonbehalf?fnr=" + PID;
+    private static final String URI = "/api/opptjeningonbehalf?pid=" + PID;
     private static final String VEILEDER_GROUP_ID = "959ead5b-99b5-466b-a0ff-5fdbc687517b";
 
     @Autowired

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/security/filter/Filter04VirtualUserTest.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/security/filter/Filter04VirtualUserTest.java
@@ -105,7 +105,7 @@ class Filter04VirtualUserTest extends FilterTest {
     }
 
     private void arrangePidInQueryString() {
-        when(request.getQueryString()).thenReturn("fnr=" + VIRTUAL_LOGGED_IN_PID.getPid());
+        when(request.getQueryString()).thenReturn("pid=" + VIRTUAL_LOGGED_IN_PID.getPid());
     }
 
     private void arrangeValidTokens() {

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/security/filter/Filter05RequestContextTest.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/security/filter/Filter05RequestContextTest.java
@@ -140,7 +140,7 @@ class Filter05RequestContextTest extends FilterTest {
     }
 
     private void arrangeVirtualUser() {
-        when(request.getQueryString()).thenReturn("fnr=" + VIRTUAL_LOGGED_IN_PID);
+        when(request.getQueryString()).thenReturn("pid=" + VIRTUAL_LOGGED_IN_PID);
     }
 
     private TokenInfo validIngressTokenInfo(UserType userType) {

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/usersession/internaluser/InternalUserAuthorizationCodeFlowTest.java
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/usersession/internaluser/InternalUserAuthorizationCodeFlowTest.java
@@ -108,7 +108,7 @@ class InternalUserAuthorizationCodeFlowTest {
         when(crypto.encrypt(anyString())).thenReturn("cryptic");
 
         mvc.perform(get(LOGIN_URL)
-                .param("redirect", "/foo/bar?fnr=" + PID.getPid()))
+                .param("redirect", "/foo/bar?pid=" + PID.getPid()))
                 .andExpect(status().isFound())
                 .andExpect(redirectedUrl("http://auth.org" +
                         "?scope=openid+profile+offline_access+https%3A%2F%2Fgraph.microsoft.com%2Fuser.read" +
@@ -139,13 +139,13 @@ class InternalUserAuthorizationCodeFlowTest {
     void callback_with_state_redirects_to_given_uri() throws Exception {
         var tokenData = new TokenData("access-token", "ID-token", "refresh-token", LocalDateTime.MIN, 1L);
         when(tokenGetter.getTokenData(any(TokenAccessParam.class), anyString())).thenReturn(tokenData);
-        when(crypto.decrypt(anyString())).thenReturn(currentTimeMillis() + ":/api/foo?fnr=" + PID.getPid());
+        when(crypto.decrypt(anyString())).thenReturn(currentTimeMillis() + ":/api/foo?pid=" + PID.getPid());
 
         mvc.perform(post(CALLBACK_URL)
                 .param("code", "abc")
                 .param("state", "cryptic"))
                 .andExpect(status().isFound())
-                .andExpect(redirectedUrl("/api/foo?fnr=" + PID.getPid()));
+                .andExpect(redirectedUrl("/api/foo?pid=" + PID.getPid()));
 
         verifyCookie();
     }


### PR DESCRIPTION
Å gå fra pensjonsopptjening til andre apper har skapt trøbbel i prod. Tenkte at det var best å holde oss til en bestemt type spørreparameter for fnr. 

Testet i Q2 med saksbehandlernavigering til og fra pensjonsopptjening. 