### PR TITLE
TPP-18 Use Chainguard Docker image

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/java21:nonroot
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-21
 ENV TZ="Europe/Oslo"
 COPY target/selvbetjening-opptjening.jar /app/app.jar
 CMD ["-jar", "/app/app.jar"]


### PR DESCRIPTION
> I Nav betaler vi for Chainguard images som er minimale images med ekstra sikkerhetstiltak. Her får du distroless images med (nesten alltid) null sårbarheter.

– [Nav Security Playbook: Valg av baseimage](https://sikkerhet.nav.no/docs/sikker-utvikling/baseimages/)