### PR TITLE
TPP-41 Add missing types of 'representasjon'

### DIFF
--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/tech/representasjon/client/pensjon/PensjonRepresentasjonClient.kt
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/tech/representasjon/client/pensjon/PensjonRepresentasjonClient.kt
@@ -93,7 +93,10 @@ class PensjonRepresentasjonClient(
         private val representasjonTypeListe: List<String> =
             listOf(
                 "PENSJON_FULLSTENDIG",
+                "PENSJON_BEGRENSET",
                 "PENSJON_SKRIV",
+                "PENSJON_KOMMUNISER",
+                "PENSJON_LES",
                 "PENSJON_PENGEMOTTAKER",
                 "PENSJON_VERGE",
                 "PENSJON_VERGE_PENGEMOTTAKER"

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/tech/representasjon/client/pensjon/PensjonRepresentasjonClientTest.kt
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/tech/representasjon/client/pensjon/PensjonRepresentasjonClientTest.kt
@@ -41,7 +41,10 @@ class PensjonRepresentasjonClientTest : FunSpec({
                     Representasjon(isValid = true, fullmaktGiverNavn = "Abc Æøå")
 
             server.takeRequest().requestUrl?.query shouldBe "validRepresentasjonstyper=PENSJON_FULLSTENDIG" +
+                    "&validRepresentasjonstyper=PENSJON_BEGRENSET" +
                     "&validRepresentasjonstyper=PENSJON_SKRIV" +
+                    "&validRepresentasjonstyper=PENSJON_KOMMUNISER" +
+                    "&validRepresentasjonstyper=PENSJON_LES" +
                     "&validRepresentasjonstyper=PENSJON_PENGEMOTTAKER" +
                     "&validRepresentasjonstyper=PENSJON_VERGE" +
                     "&validRepresentasjonstyper=PENSJON_VERGE_PENGEMOTTAKER" +


### PR DESCRIPTION
Tilbakefører representasjonstyper som ble feilaktig slettet i [PR 262](https://github.com/navikt/pensjon-selvbetjening-opptjening-backend/pull/262/files) (de var angitt i `FullmaktClient`, som ble erstattet av `PensjonRepresentasjonClient`).

NB: Siden samhandlerfullmakt ikke lenger støttes, er `PENSJON_SAMHANDLER` og `PENSJON_SAMHANDLER_ADMIN` utelatt.