### PR TITLE
TPP-300 Support encrypted OBO cookie

### DIFF
--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/tech/security/egress/SecurityContextEnricher.kt
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/tech/security/egress/SecurityContextEnricher.kt
@@ -19,20 +19,12 @@ import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 import org.springframework.util.StringUtils.hasLength
-import kotlin.also
-import kotlin.collections.filter
-import kotlin.collections.firstOrNull
-import kotlin.collections.map
-import kotlin.collections.orEmpty
-import kotlin.let
-import kotlin.text.contains
-import kotlin.text.equals
 
 @Component
 class SecurityContextEnricher(
     val tokenSuppliers: EgressTokenSuppliersByService,
     private val authTypeDeducer: AuthTypeDeducer,
-    private val securityContextPidExtractor: SecurityContextPidExtractor,
+    private val pidExtractor: SecurityContextPidExtractor,
     private val pidDecrypter: PidEncryptionService,
     private val representasjonService: RepresentasjonService
 ) {
@@ -48,66 +40,6 @@ class SecurityContextEnricher(
         }
     }
 
-    private fun enrichStep1(auth: Authentication) =
-        EnrichedAuthentication(
-            initialAuth = auth,
-            authType = authTypeDeducer.deduce(isRepresentant = false),
-            egressTokenSuppliersByService = tokenSuppliers,
-            target = selv()
-        )
-
-    private fun enrichStep2(auth: EnrichedAuthentication, request: HttpServletRequest): EnrichedAuthentication {
-        val kryptertPid = veiledetPid(request)
-        var veiledetPid: Pid?
-        if (kryptertPid?.contains(ENCRYPTION_MARK) == true) {
-            veiledetPid = Pid(pidDecrypter.decryptPid(kryptertPid))
-        } else {
-            veiledetPid = kryptertPid?.let { Pid(it) }
-        }
-        return EnrichedAuthentication(
-            initialAuth = auth,
-            authType = auth.authType,
-            egressTokenSuppliersByService = tokenSuppliers,
-            target = veiledetPid?.let(::personUnderVeiledning) ?: selv()
-        )
-    }
-
-    private fun veiledetPid(request: HttpServletRequest): String? =
-        ((headerPid(request)
-            ?: request.getParameter("pid")))
-
-    private fun applyPotentialFullmakt(
-        auth: Authentication,
-        request: HttpServletRequest
-    ): Authentication =
-        onBehalfOfPid(request.cookies)?.let {
-            if (validRepresentasjonForhold(it))
-                enrichWithFullmakt(auth, it).also { Metrics.countEvent(eventName = "obo", result = "ok") }
-            else
-                invalidRepresentasjonForhold()
-        } ?: auth
-
-    /**
-     * NB: Dette støtter ikke brukstilfellet der veileder er logget inn på vegne av en fullmektig.
-     * Dette fordi pensjon-representasjon henter ut PID fra TokenX-tokenet (som ikke finnes når veileder er logget inn).
-     */
-    private fun validRepresentasjonForhold(pid: Pid) =
-        representasjonService.hasValidRepresentasjonsforhold(pid).isValid
-
-    private fun enrichWithFullmakt(auth: Authentication, fullmaktGiverPid: Pid) =
-        EnrichedAuthentication(
-            initialAuth = auth,
-            authType = authTypeDeducer.deduce(isRepresentant = true),
-            egressTokenSuppliersByService = tokenSuppliers,
-            target = RepresentasjonTarget(pid = fullmaktGiverPid, rolle = RepresentertRolle.FULLMAKT_GIVER)
-        )
-
-    private fun selv() =
-        RepresentasjonTarget(
-            pid = securityContextPidExtractor.pid(),
-            rolle = RepresentertRolle.SELV
-        )
-
     private fun anonymousAuthentication() =
         EnrichedAuthentication(
             initialAuth = null,
@@ -116,30 +48,104 @@ class SecurityContextEnricher(
             target = RepresentasjonTarget(rolle = RepresentertRolle.NONE)
         )
 
-    private fun headerPid(request: HttpServletRequest): String? =
-        request.getHeader(CustomHttpHeaders.PID)?.let {
-            when {
-                hasLength(it).not() -> null
-                else -> it
-            }
-        }
+    /**
+     * enrichStep1 is a precondition for the personUnderVeiledning call in enrichStep2.
+     */
+    private fun enrichStep1(auth: Authentication) =
+        EnrichedAuthentication(
+            initialAuth = auth,
+            authType = authTypeDeducer.deduce(isRepresentant = false),
+            egressTokenSuppliersByService = tokenSuppliers,
+            target = selv()
+        )
+
+    private fun enrichStep2(auth: EnrichedAuthentication, request: HttpServletRequest) =
+        EnrichedAuthentication(
+            initialAuth = auth,
+            authType = auth.authType,
+            egressTokenSuppliersByService = tokenSuppliers,
+            target = personUnderVeiledning(request) ?: selv()
+        )
+
+    private fun enrichWithFullmakt(auth: Authentication, fullmaktgiverPid: Pid) =
+        EnrichedAuthentication(
+            initialAuth = auth,
+            authType = authTypeDeducer.deduce(isRepresentant = true),
+            egressTokenSuppliersByService = tokenSuppliers,
+            target = fullmaktgiver(pid = fullmaktgiverPid)
+        )
+
+    private fun selv(): RepresentasjonTarget =
+        selv(pid = pidExtractor.pid())
+
+    private fun personUnderVeiledning(request: HttpServletRequest): RepresentasjonTarget? =
+        onBehalfOfPid(request)
+            ?.let { personUnderVeiledning(pid = Pid(decrypt(it))) }
+
+    private fun applyPotentialFullmakt(
+        auth: Authentication,
+        request: HttpServletRequest
+    ): Authentication =
+        onBehalfOfPid(request.cookies)?.let {
+            if (validRepresentasjonForhold(pid = it))
+                enrichWithFullmakt(auth, fullmaktgiverPid = it).also { countOnBehalfOfEvent(result = "ok") }
+            else
+                invalidRepresentasjonForhold()
+        } ?: auth
+
+    /**
+     * NB: Dette støtter ikke brukstilfellet der veileder er logget inn på vegne av en fullmektig.
+     * Dette fordi pensjon-representasjon henter ut PID fra TokenX-tokenet (som ikke finnes når veileder er logget inn).
+     */
+    private fun validRepresentasjonForhold(pid: Pid): Boolean =
+        representasjonService.hasValidRepresentasjonsforhold(fullmaktGiverPid = pid).isValid
 
     private fun onBehalfOfPid(cookies: Array<Cookie>?): Pid? =
         cookies.orEmpty()
             .filter { ON_BEHALF_OF_COOKIE_NAME.equals(it.name, ignoreCase = true) }
-            .map { Pid(it.value) }
+            .map { Pid((decrypt(it.value.orEmpty()))) }
             .firstOrNull()
 
+    private fun decrypt(value: String): String =
+        if (value.contains(ENCRYPTION_MARK))
+            pidDecrypter.decryptPid(encryptedPid = value).orEmpty()
+        else
+            value
+
     private companion object {
-        const val ENCRYPTION_MARK = "."
+        private const val ENCRYPTION_MARK = "."
         private const val ON_BEHALF_OF_COOKIE_NAME = "nav-obo"
+
+        private fun onBehalfOfPid(request: HttpServletRequest): String? =
+            headerPid(request) ?: request.getParameter("pid")
+
+        private fun headerPid(request: HttpServletRequest): String? =
+            request.getHeader(CustomHttpHeaders.PID)?.let {
+                when {
+                    hasLength(it).not() -> null
+                    else -> it
+                }
+            }
+
+        /**
+         * NB: pid is null when veileder is logged in (veileder is identified by Nav-ID, not PID).
+         */
+        private fun selv(pid: Pid?) =
+            RepresentasjonTarget(pid, rolle = RepresentertRolle.SELV)
+
+        private fun fullmaktgiver(pid: Pid) =
+            RepresentasjonTarget(pid, rolle = RepresentertRolle.FULLMAKT_GIVER)
 
         private fun personUnderVeiledning(pid: Pid) =
             RepresentasjonTarget(pid, rolle = RepresentertRolle.UNDER_VEILEDNING)
 
         private fun invalidRepresentasjonForhold(): Nothing {
-            Metrics.countEvent(eventName = "obo", result = "avvist")
+            countOnBehalfOfEvent(result = "avvist")
             throw AccessDeniedException(AccessDeniedReason.INVALID_REPRESENTASJON.name)
+        }
+
+        private fun countOnBehalfOfEvent(result: String) {
+            Metrics.countEvent(eventName = "obo", result)
         }
     }
 }

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/tech/security/egress/SecurityContextEnricherTest.kt
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/tech/security/egress/SecurityContextEnricherTest.kt
@@ -8,7 +8,6 @@ import io.mockk.mockk
 import io.mockk.verify
 import jakarta.servlet.http.Cookie
 import jakarta.servlet.http.HttpServletRequest
-import no.nav.pensjon.selvbetjeningopptjening.mock.TestObjects.pid
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.Pid
 import no.nav.pensjon.selvbetjeningopptjening.tech.crypto.PidEncryptionService
 import no.nav.pensjon.selvbetjeningopptjening.tech.representasjon.Representasjon
@@ -24,7 +23,7 @@ class SecurityContextEnricherTest : FunSpec({
     val tokenSuppliers = EgressTokenSuppliersByService(emptyMap())
 
     test("enrichAuthentication uses plaintext PID from header if not encrypted") {
-        setSecurityContext(authentication = mockk())
+        arrangeSecurityContext(authentication = mockk())
         val securityContextPidExtractor = mockk<SecurityContextPidExtractor>(relaxed = true)
 
         SecurityContextEnricher(
@@ -34,15 +33,15 @@ class SecurityContextEnricherTest : FunSpec({
             pidDecrypter = mockk(),
             representasjonService = mockk()
         ).enrichAuthentication(
-            request = arrangeFoedselsnummerInHeader(pid.pid), // => PID in the request header
+            request = arrangeFoedselsnummerInHeader(LOGGED_IN_PID.pid), // => PID in the request header
             response = mockk()
         )
         verify(exactly = 1) { securityContextPidExtractor.pid() }
-        securityContextTargetPid()?.pid shouldBe "22925399748"
+        securityContextTargetPid() shouldBe LOGGED_IN_PID
     }
 
     test("if no PID in request header then enrichAuthentication gets PID from security context") {
-        setSecurityContext(authentication = mockk())
+        arrangeSecurityContext(authentication = mockk())
         val securityContextPidExtractor = mockk<SecurityContextPidExtractor>(relaxed = true)
 
         SecurityContextEnricher(
@@ -60,7 +59,7 @@ class SecurityContextEnricherTest : FunSpec({
     }
 
     test("enrichAuthentication decrypts encrypted PID in url") {
-        setSecurityContext(authentication = mockk())
+        arrangeSecurityContext(authentication = mockk())
         val securityContextPidExtractor = mockk<SecurityContextPidExtractor>(relaxed = true)
 
         SecurityContextEnricher(
@@ -70,87 +69,105 @@ class SecurityContextEnricherTest : FunSpec({
             pidDecrypter = arrangeDecryption(),
             representasjonService = mockk()
         ).enrichAuthentication(
-            request = arrangeFoedselsnummerInUrl("encrypted.string.containing.dot"), // encrypted PID
+            request = arrangeFoedselsnummerInUrl("contains.dot"), // encrypted PID
             response = mockk()
         )
         verify(exactly = 1) { securityContextPidExtractor.pid() }
-        securityContextTargetPid()?.pid shouldBe "12906498357"
+        securityContextTargetPid() shouldBe ON_BEHALF_OF_PID
     }
 
     test("enrichAuthentication decrypts encrypted PID in header") {
-        setSecurityContext(authentication = mockk())
-        val securityContextPidExtractor = mockk<SecurityContextPidExtractor>(relaxed = true)
+        arrangeSecurityContext(authentication = mockk())
 
         SecurityContextEnricher(
             tokenSuppliers,
             authTypeDeducer = mockk(relaxed = true),
-            securityContextPidExtractor,
+            pidExtractor = arrangeSecurityContextPidExtractor(pid = null),
             pidDecrypter = arrangeDecryption(),
             representasjonService = mockk()
         ).enrichAuthentication(
-            request = arrangeFoedselsnummerInHeader("encrypted.string.containing.dot"), // encrypted PID
+            request = arrangeFoedselsnummerInHeader("contains.dot"), // encrypted PID
             response = mockk()
         )
-        verify(exactly = 1) { securityContextPidExtractor.pid() }
-        securityContextTargetPid()?.pid shouldBe "12906498357"
+
+        securityContextTargetPid() shouldBe ON_BEHALF_OF_PID
+    }
+
+    test("enrichAuthentication decrypts encrypted PID in cookie") {
+        arrangeSecurityContext(authentication = mockk())
+
+        SecurityContextEnricher(
+            tokenSuppliers,
+            authTypeDeducer = mockk(relaxed = true),
+            pidExtractor = arrangeSecurityContextPidExtractor(pid = LOGGED_IN_PID),
+            pidDecrypter = arrangeDecryption(),
+            representasjonService = arrange(Representasjon(isValid = true, fullmaktGiverNavn = "F. Giver"))
+        ).enrichAuthentication(
+            request = arrangeOnBehalfOfCookie(value = "contains.dot"), // encrypted PID
+            response = mockk()
+        )
+
+        securityContextTargetPid() shouldBe ON_BEHALF_OF_PID // decrypted PID
     }
 
     test("enrichAuthentication uses plaintext PID from url if not encrypted") {
-        setSecurityContext(authentication = mockk())
-        val securityContextPidExtractor = mockk<SecurityContextPidExtractor>(relaxed = true)
+        arrangeSecurityContext(authentication = mockk())
 
         SecurityContextEnricher(
             tokenSuppliers,
             authTypeDeducer = mockk(relaxed = true),
-            securityContextPidExtractor,
+            pidExtractor = arrangeSecurityContextPidExtractor(pid = null),
             pidDecrypter = mockk(),
             representasjonService = mockk()
         ).enrichAuthentication(
-            request = arrangeFoedselsnummerInUrl("12906498357"), // not encrypted
+            request = arrangeFoedselsnummerInUrl(ON_BEHALF_OF_PID.pid), // not encrypted
             response = mockk()
         )
-        verify(exactly = 1) { securityContextPidExtractor.pid() }
-        securityContextTargetPid()?.pid shouldBe "12906498357"
+
+        securityContextTargetPid() shouldBe ON_BEHALF_OF_PID
     }
 
     test("enrichAuthentication sets target PID from OBO cookie if valid representasjon") {
-        setSecurityContext(authentication = mockk())
+        arrangeSecurityContext(authentication = mockk())
 
         SecurityContextEnricher(
             tokenSuppliers,
             authTypeDeducer = mockk(relaxed = true),
-            securityContextPidExtractor = arrangeSecurityContextPidExtractor(),
+            pidExtractor = arrangeSecurityContextPidExtractor(pid = LOGGED_IN_PID),
             pidDecrypter = mockk(),
             representasjonService = arrange(Representasjon(isValid = true, fullmaktGiverNavn = "F. Giver"))
         ).enrichAuthentication(
-            request = arrangeOnBehalfOfCookie(),
+            request = arrangeOnBehalfOfCookie(value = ON_BEHALF_OF_PID.pid),
             response = mockk()
         )
 
-        securityContextTargetPid()?.pid shouldBe "12906498357"
+        securityContextTargetPid() shouldBe ON_BEHALF_OF_PID
     }
 
     test("enrichAuthentication throws AccessDeniedException if invalid representasjon") {
-        setSecurityContext(authentication = mockk())
+        arrangeSecurityContext(authentication = mockk())
 
         shouldThrow<org.springframework.security.access.AccessDeniedException> {
             SecurityContextEnricher(
                 tokenSuppliers,
                 authTypeDeducer = mockk(relaxed = true),
-                securityContextPidExtractor = arrangeSecurityContextPidExtractor(),
+                pidExtractor = arrangeSecurityContextPidExtractor(pid = LOGGED_IN_PID),
                 pidDecrypter = mockk(),
                 representasjonService = arrange(Representasjon(isValid = false, fullmaktGiverNavn = ""))
             ).enrichAuthentication(
-                request = arrangeOnBehalfOfCookie(),
+                request = arrangeOnBehalfOfCookie(value = ON_BEHALF_OF_PID.pid),
                 response = mockk()
             )
         }.message shouldBe "INVALID_REPRESENTASJON"
 
-        securityContextTargetPid()?.pid shouldBe null
+        securityContextTargetPid() shouldBe LOGGED_IN_PID // not on-behalf-of PID
     }
 })
 
-private fun setSecurityContext(authentication: Authentication) {
+private val LOGGED_IN_PID = Pid("22925399748")
+private val ON_BEHALF_OF_PID = Pid("12906498357")
+
+private fun arrangeSecurityContext(authentication: Authentication) {
     SecurityContextHolder.setContext(SecurityContextImpl(authentication))
 }
 
@@ -169,23 +186,25 @@ private fun arrangeFoedselsnummerInHeader(value: String?) =
         every { getParameter("pid") } returns null
     }
 
-private fun arrangeOnBehalfOfCookie() =
+private fun arrangeOnBehalfOfCookie(value: String) =
     mockk<HttpServletRequest>(relaxed = true).apply {
-        every { cookies } returns listOf(Cookie("nav-obo", "12906498357")).toTypedArray()
+        every { cookies } returns listOf(Cookie("nav-obo", value)).toTypedArray()
         every { getParameter("pid") } returns null
     }
 
 private fun arrange(representasjon: Representasjon) =
     mockk<RepresentasjonService>().apply {
-        every { hasValidRepresentasjonsforhold(Pid("12906498357")) } returns representasjon
+        every {
+            hasValidRepresentasjonsforhold(fullmaktGiverPid = ON_BEHALF_OF_PID)
+        } returns representasjon
     }
 
 private fun arrangeDecryption() =
     mockk<PidEncryptionService>().apply {
-        every { decryptPid("encrypted.string.containing.dot") } returns "12906498357"
+        every { decryptPid("contains.dot") } returns ON_BEHALF_OF_PID.pid
     }
 
-private fun arrangeSecurityContextPidExtractor(): SecurityContextPidExtractor =
+private fun arrangeSecurityContextPidExtractor(pid: Pid?): SecurityContextPidExtractor =
     mockk<SecurityContextPidExtractor>().apply {
-        every { pid() } returns null
+        every { pid() } returns pid
     }


### PR DESCRIPTION
Se [Jira-sak TPP-300](https://jira.adeo.no/browse/TPP-300) for bakgrunn.

Hovedendringen er at cookien som inneholder PID (fødselsnummer) nå tillates å være kryptert:
Før:
```
cookies...
            .map { Pid(it.value)) }
```
Etter:
```
cookies...
            .map { Pid((decrypt(it.value.orEmpty()))) }
```
med tilhørende ny enhetstest:
```
test("enrichAuthentication decrypts encrypted PID in cookie")
```

Øvrige endringer er forbedret kodestruktur.
