### PR TITLE
TPP-507 Add 'merknader' endpoint

### DIFF
--- a/.nais/dev-gcp.yml
+++ b/.nais/dev-gcp.yml
@@ -60,9 +60,9 @@ spec:
     inbound:
       rules:
         - application: pensjon-selvbetjening-opptjening-frontend
-          cluster: dev-gcp
         - application: pensjon-veiledning-opptjening-frontend
-          cluster: dev-gcp
+        - application: pensjonskalkulator-backend
+          namespace: pensjonskalkulator
         - application: azure-token-generator # dev only
           namespace: nais
         - application: tokenx-token-generator # dev only
@@ -93,8 +93,6 @@ spec:
         - host: skjermede-personer-pip.intern.dev.nav.no
         - host: test.idporten.no
   env:
-    - name: NO_NAV_SECURITY_JWT_ISSUER_SELVBETJENING_COOKIE_NAME
-      value: selvbetjening-idtoken
     - name: PENSJON_REPRESENTASJON_APP_ID
       value: dev-fss:pensjon-person:pensjon-representasjon-q2
     - name: PENSJON_REPRESENTASJON_URL

--- a/.nais/prod-gcp.yml
+++ b/.nais/prod-gcp.yml
@@ -59,9 +59,9 @@ spec:
     inbound:
       rules:
         - application: pensjon-selvbetjening-opptjening-frontend
-          cluster: prod-gcp
         - application: pensjon-veiledning-opptjening-frontend
-          cluster: prod-gcp
+        - application: pensjonskalkulator-backend
+          namespace: pensjonskalkulator
     outbound:
       rules:
         - application: pdl-api
@@ -89,8 +89,6 @@ spec:
         - host: idporten.no
         - host: oidc.difi.no
   env:
-    - name: NO_NAV_SECURITY_JWT_ISSUER_SELVBETJENING_COOKIE_NAME
-      value: selvbetjening-idtoken
     - name: PENSJON_REPRESENTASJON_APP_ID
       value: prod-fss:pensjon-person:pensjon-representasjon
     - name: PENSJON_REPRESENTASJON_URL

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/api/merknad/v1/MerknadController.kt
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/api/merknad/v1/MerknadController.kt
@@ -2,7 +2,7 @@ package no.nav.pensjon.selvbetjeningopptjening.api.merknad.v1
 
 import mu.KotlinLogging
 import no.nav.pensjon.selvbetjeningopptjening.api.merknad.v1.acl.MerknaderV1
-import no.nav.pensjon.selvbetjeningopptjening.api.merknad.v1.acl.ResultMapper.transferable
+import no.nav.pensjon.selvbetjeningopptjening.api.merknad.v1.acl.MerknadMapper.transferable
 import no.nav.pensjon.selvbetjeningopptjening.consumer.FailedCallingExternalServiceException
 import no.nav.pensjon.selvbetjeningopptjening.merknad.MerknadService
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.PidValidationException

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/api/merknad/v1/MerknadController.kt
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/api/merknad/v1/MerknadController.kt
@@ -1,0 +1,36 @@
+package no.nav.pensjon.selvbetjeningopptjening.api.merknad.v1
+
+import mu.KotlinLogging
+import no.nav.pensjon.selvbetjeningopptjening.api.merknad.v1.acl.MerknaderV1
+import no.nav.pensjon.selvbetjeningopptjening.api.merknad.v1.acl.ResultMapper.transferable
+import no.nav.pensjon.selvbetjeningopptjening.consumer.FailedCallingExternalServiceException
+import no.nav.pensjon.selvbetjeningopptjening.merknad.MerknadService
+import no.nav.pensjon.selvbetjeningopptjening.opptjening.PidValidationException
+import no.nav.pensjon.selvbetjeningopptjening.tech.security.ingress.TargetPidExtractor
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+
+@RestController
+@RequestMapping("api")
+class MerknadController(
+    private val service: MerknadService,
+    private val pidGetter: TargetPidExtractor
+) {
+    private val log = KotlinLogging.logger { }
+
+    @GetMapping("/merknader")
+    fun getMerknader(): MerknaderV1 {
+        try {
+            return transferable(service.merknaderPerAar(pidGetter.pid()))
+        } catch (e: PidValidationException) {
+            log.error(e) { "PID validation failed" }
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, e.message, e)
+        } catch (e: FailedCallingExternalServiceException) {
+            log.error(e) { "External service call failed" }
+            throw ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, e.message, e)
+        }
+    }
+}

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/api/merknad/v1/acl/MerknadMapper.kt
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/api/merknad/v1/acl/MerknadMapper.kt
@@ -2,7 +2,7 @@ package no.nav.pensjon.selvbetjeningopptjening.api.merknad.v1.acl
 
 import no.nav.pensjon.selvbetjeningopptjening.merknad.Merknader
 
-object ResultMapper {
+object MerknadMapper {
 
     fun transferable(source: Merknader) =
         MerknaderV1(

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/api/merknad/v1/acl/MerknaderV1.kt
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/api/merknad/v1/acl/MerknaderV1.kt
@@ -1,0 +1,28 @@
+package no.nav.pensjon.selvbetjeningopptjening.api.merknad.v1.acl
+
+import no.nav.pensjon.selvbetjeningopptjening.model.code.MerknadCode
+
+data class MerknaderV1(
+    val merknaderPerAar: Map<Int, List<MerknadCodeV1>>
+)
+
+enum class MerknadCodeV1(private val internalValue: MerknadCode) {
+
+    AFP(internalValue = MerknadCode.AFP),
+    REFORM(internalValue = MerknadCode.REFORM),
+    INGEN_OPPTJENING(internalValue = MerknadCode.INGEN_OPPTJENING),
+    UFOREGRAD(internalValue = MerknadCode.UFOREGRAD),
+    DAGPENGER(internalValue = MerknadCode.DAGPENGER),
+    FORSTEGANGSTJENESTE(internalValue = MerknadCode.FORSTEGANGSTJENESTE),
+    OMSORGSOPPTJENING(internalValue = MerknadCode.OMSORGSOPPTJENING),
+    GRADERT_UTTAK(internalValue = MerknadCode.GRADERT_UTTAK),
+    HELT_UTTAK(internalValue = MerknadCode.HELT_UTTAK),
+    // Special value representing missing/unknown value:
+    UNKNOWN(internalValue = MerknadCode.TESTMERKNAD); // TESTMERKNAD skal ikke brukes i API v1
+
+    companion object {
+        fun fromInternalValue(value: MerknadCode): MerknadCodeV1 =
+            entries.singleOrNull { it.internalValue == value }
+                ?: throw IllegalArgumentException("Intern verdi ikke støttet i API v1 - MerknadCode $value")
+    }
+}

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/api/merknad/v1/acl/ResultMapper.kt
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/api/merknad/v1/acl/ResultMapper.kt
@@ -1,0 +1,13 @@
+package no.nav.pensjon.selvbetjeningopptjening.api.merknad.v1.acl
+
+import no.nav.pensjon.selvbetjeningopptjening.merknad.Merknader
+
+object ResultMapper {
+
+    fun transferable(source: Merknader) =
+        MerknaderV1(
+            merknaderPerAar = source.perAar.map { (aar, code) ->
+                aar to code.map(MerknadCodeV1::fromInternalValue)
+            }.toMap()
+        )
+}

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/gruppe/Brukergruppe.kt
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/gruppe/Brukergruppe.kt
@@ -1,0 +1,163 @@
+package no.nav.pensjon.selvbetjeningopptjening.gruppe
+
+import no.nav.pensjon.selvbetjeningopptjening.merknad.MerknadArguments
+import no.nav.pensjon.selvbetjeningopptjening.merknad.MerknadAssemblerForBrukergruppe123
+import no.nav.pensjon.selvbetjeningopptjening.merknad.MerknadAssemblerForBrukergruppe4
+import no.nav.pensjon.selvbetjeningopptjening.merknad.MerknadAssemblerForBrukergruppe5
+import no.nav.pensjon.selvbetjeningopptjening.merknad.Merknader
+import no.nav.pensjon.selvbetjeningopptjening.model.code.UserGroup.getOpptjeningForUserGroup4
+import no.nav.pensjon.selvbetjeningopptjening.model.code.UserGroup.getOpptjeningForUserGroup5
+import no.nav.pensjon.selvbetjeningopptjening.model.code.UserGroup.getOpptjeningForUserGroups123
+import no.nav.pensjon.selvbetjeningopptjening.opptjening.*
+import no.nav.pensjon.selvbetjeningopptjening.opptjening.dto.OpptjeningResponse
+import no.nav.pensjon.selvbetjeningopptjening.person.Person
+
+enum class Brukergruppe(
+    val harRestpensjon: Boolean,
+    val harBeholdning: Boolean = false,
+    val harInntekt: Boolean = false,
+    val harPensjonspoeng: Boolean = false,
+    val opptjeningAssembler: (OpptjeningArguments) -> OpptjeningResponse,
+    val merknadAssembler: (MerknadArguments) -> Merknader,
+    val aldersbeskrivelse: String
+) {
+    EN(
+        harRestpensjon = false,
+        harPensjonspoeng = true,
+        opptjeningAssembler = { getOpptjeningForUserGroups123(it) },
+        merknadAssembler = { merknaderForBrukergruppe1og2og3(it) },
+        aldersbeskrivelse = "Født før 1954"
+    ),
+    TO(
+        harRestpensjon = true,
+        harPensjonspoeng = true,
+        opptjeningAssembler = { getOpptjeningForUserGroups123(it) },
+        merknadAssembler = { merknaderForBrukergruppe1og2og3(it) },
+        aldersbeskrivelse = "Født før 1954"
+    ),
+    TRE(
+        harRestpensjon = true,
+        harPensjonspoeng = true,
+        opptjeningAssembler = { getOpptjeningForUserGroups123(it) },
+        merknadAssembler = { merknaderForBrukergruppe1og2og3(it) },
+        aldersbeskrivelse = "Født før 1954"
+    ),
+    FIRE(
+        harRestpensjon = true,
+        harBeholdning = true,
+        harPensjonspoeng = true,
+        opptjeningAssembler = { getOpptjeningForUserGroup4(it) },
+        merknadAssembler = { merknaderForBrukergruppe4(it) },
+        aldersbeskrivelse = "Født 1954-1962"
+    ),
+    FEM(
+        harRestpensjon = true,
+        harBeholdning = true,
+        harInntekt = true,
+        opptjeningAssembler = { getOpptjeningForUserGroup5(it) },
+        merknadAssembler = { merknaderForBrukergruppe5(it) },
+        aldersbeskrivelse = "Født etter 1962"
+    );
+
+    companion object {
+        fun merknaderForBrukergruppe1og2og3(args: MerknadArguments): Merknader =
+            merknaderForBrukergruppe1og2og3(
+                args.person,
+                args.restpensjonListe,
+                args.uttaksgradListe,
+                args.afpHistorikk,
+                args.ufoereHistorikk,
+                args.pensjonspoengListe
+            )
+
+        fun merknaderForBrukergruppe4(args: MerknadArguments): Merknader =
+            merknaderForBrukergruppe4(
+                args.person,
+                args.restpensjonListe,
+                args.uttaksgradListe,
+                args.afpHistorikk,
+                args.ufoereHistorikk,
+                args.pensjonspoengListe,
+                args.beholdningListe
+            )
+
+        fun merknaderForBrukergruppe5(args: MerknadArguments): Merknader =
+            merknaderForBrukergruppe5(
+                args.person,
+                args.restpensjonListe,
+                args.uttaksgradListe,
+                args.afpHistorikk,
+                args.ufoereHistorikk,
+                args.inntektListe,
+                args.beholdningListe
+            )
+
+        private fun merknaderForBrukergruppe1og2og3(
+            person: Person,
+            restpensjonListe: List<Restpensjon>,
+            uttaksgradListe: List<Uttaksgrad>,
+            afpHistorikk: AfpHistorikk?,
+            ufoereHistorikk: UforeHistorikk?,
+            pensjonspoengListe: List<Pensjonspoeng>
+        ): Merknader {
+            val basis = OpptjeningBasis(
+                pensjonspoengListe,
+                emptyList(), // beholdninger irrelevant her
+                restpensjonListe,
+                emptyList(), // inntekter irrelevant her
+                uttaksgradListe,
+                emptyList(),
+                afpHistorikk,
+                ufoereHistorikk
+            )
+
+            return MerknadAssemblerForBrukergruppe123().merknader(person, basis)
+        }
+
+        private fun merknaderForBrukergruppe4(
+            person: Person,
+            restpensjonListe: List<Restpensjon>,
+            uttaksgradListe: List<Uttaksgrad>,
+            afpHistorikk: AfpHistorikk?,
+            ufoereHistorikk: UforeHistorikk?,
+            pensjonspoengListe: List<Pensjonspoeng>,
+            beholdningListe: List<Beholdning>
+        ): Merknader {
+            val basis = OpptjeningBasis(
+                pensjonspoengListe,
+                beholdningListe,
+                restpensjonListe,
+                emptyList(), // inntekter irrelevant her
+                uttaksgradListe,
+                emptyList(),
+                afpHistorikk,
+                ufoereHistorikk
+            )
+
+            return MerknadAssemblerForBrukergruppe4().merknader(person, basis)
+        }
+
+        private fun merknaderForBrukergruppe5(
+            person: Person,
+            restpensjonListe: List<Restpensjon>,
+            uttaksgradListe: List<Uttaksgrad>,
+            afpHistorikk: AfpHistorikk?,
+            ufoereHistorikk: UforeHistorikk?,
+            inntektListe: List<Inntekt>,
+            beholdningListe: List<Beholdning>
+        ): Merknader {
+            val basis = OpptjeningBasis(
+                emptyList(), // pensjonspoeng irrelevant her
+                beholdningListe,
+                restpensjonListe,
+                inntektListe,
+                uttaksgradListe,
+                emptyList(),
+                afpHistorikk,
+                ufoereHistorikk
+            )
+
+            return MerknadAssemblerForBrukergruppe5().merknader(person, basis)
+        }
+    }
+}

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/merknad/MerknadArguments.kt
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/merknad/MerknadArguments.kt
@@ -1,0 +1,18 @@
+package no.nav.pensjon.selvbetjeningopptjening.merknad
+
+import no.nav.pensjon.selvbetjeningopptjening.opptjening.*
+import no.nav.pensjon.selvbetjeningopptjening.person.Person
+
+/**
+ * Informasjon som behøves for å utlede merknader.
+ */
+data class MerknadArguments(
+    val person: Person,
+    val uttaksgradListe: List<Uttaksgrad>,
+    val afpHistorikk: AfpHistorikk?,
+    val ufoereHistorikk: UforeHistorikk?,
+    val inntektListe: List<Inntekt>,
+    val beholdningListe: List<Beholdning>,
+    val pensjonspoengListe: List<Pensjonspoeng>,
+    val restpensjonListe: List<Restpensjon>
+)

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/merknad/MerknadAssemblerForBrukergruppe123.kt
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/merknad/MerknadAssemblerForBrukergruppe123.kt
@@ -1,0 +1,50 @@
+package no.nav.pensjon.selvbetjeningopptjening.merknad
+
+import no.nav.pensjon.selvbetjeningopptjening.opptjening.*
+import no.nav.pensjon.selvbetjeningopptjening.person.Person
+import org.springframework.stereotype.Component
+
+@Component
+class MerknadAssemblerForBrukergruppe123 : OpptjeningAssembler() {
+
+    fun merknader(person: Person, basis: OpptjeningBasis): Merknader =
+        merknader(
+            person,
+            pensjonspoengListe = basis.pensjonspoengList.orEmpty(),
+            restpensjonListe = basis.restpensjoner.orEmpty(),
+            uttaksgradListe = basis.uttaksgrader.orEmpty(),
+            afpHistorikk = basis.afpHistorikk,
+            ufoereHistorikk = basis.uforeHistorikk
+        )
+
+    private fun merknader(
+        person: Person,
+        pensjonspoengListe: List<Pensjonspoeng>,
+        restpensjonListe: List<Restpensjon>,
+        uttaksgradListe: List<Uttaksgrad>,
+        afpHistorikk: AfpHistorikk?,
+        ufoereHistorikk: UforeHistorikk?
+    ): Merknader {
+        val opptjeningPerAar: Map<Int, Opptjening> = getOpptjeningerByYear(pensjonspoengListe, restpensjonListe)
+        populatePensjonspoeng(opptjeningPerAar, pensjonspoengListe, uttaksgradListe)
+
+        if (opptjeningPerAar.isEmpty())
+            return Merknader(perAar = emptyMap())
+
+        val foersteAar: Int = getFirstYearWithOpptjening(person.getFodselsdato())
+        val sisteAar: Int = findLatestOpptjeningYear(opptjeningPerAar)
+        setRestpensjoner(opptjeningPerAar, restpensjonListe)
+        removeFutureOpptjening(opptjeningPerAar, sisteAar)
+        putYearsWithNoOpptjening(opptjeningPerAar, foersteAar, sisteAar)
+
+        return Merknader(
+            perAar = MerknadDeducer.merknaderPerAar(
+                opptjeningPerAar,
+                beholdningListe = emptyList(),
+                afpHistorikk,
+                ufoereHistorikk,
+                erBrukergruppe4Eller5 = false
+            )
+        )
+    }
+}

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/merknad/MerknadAssemblerForBrukergruppe4.kt
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/merknad/MerknadAssemblerForBrukergruppe4.kt
@@ -1,0 +1,53 @@
+package no.nav.pensjon.selvbetjeningopptjening.merknad
+
+import no.nav.pensjon.selvbetjeningopptjening.opptjening.*
+import no.nav.pensjon.selvbetjeningopptjening.person.Person
+import org.springframework.stereotype.Component
+
+@Component
+class MerknadAssemblerForBrukergruppe4 : OpptjeningAssembler() {
+
+    fun merknader(person: Person, basis: OpptjeningBasis): Merknader =
+        merknader(
+            person,
+            pensjonspoengListe = basis.pensjonspoengList.orEmpty(),
+            beholdningListe = basis.pensjonsbeholdninger.orEmpty(),
+            restpensjonListe = basis.restpensjoner.orEmpty(),
+            uttaksgradListe = basis.uttaksgrader.orEmpty(),
+            afpHistorikk = basis.afpHistorikk,
+            ufoereHistorikk = basis.uforeHistorikk
+        )
+
+    private fun merknader(
+        person: Person,
+        pensjonspoengListe: List<Pensjonspoeng>,
+        beholdningListe: List<Beholdning>,
+        restpensjonListe: List<Restpensjon>,
+        uttaksgradListe: List<Uttaksgrad>,
+        afpHistorikk: AfpHistorikk?,
+        ufoereHistorikk: UforeHistorikk?
+    ): Merknader {
+        val opptjeningPerAar = getOpptjeningerByYear(pensjonspoengListe, restpensjonListe)
+        populatePensjonspoeng(opptjeningPerAar, pensjonspoengListe, uttaksgradListe)
+        populatePensjonsbeholdning(opptjeningPerAar, getBeholdningerByYear(beholdningListe))
+
+        if (opptjeningPerAar.isEmpty())
+            return Merknader(perAar = emptyMap())
+
+        val foersteAar = getFirstYearWithOpptjening(person.getFodselsdato())
+        val sisteAar = findLatestOpptjeningYear(opptjeningPerAar)
+        setRestpensjoner(opptjeningPerAar, restpensjonListe)
+        removeFutureOpptjening(opptjeningPerAar, sisteAar)
+        putYearsWithNoOpptjening(opptjeningPerAar, foersteAar, sisteAar)
+
+        return Merknader(
+            perAar = MerknadDeducer.merknaderPerAar(
+                opptjeningPerAar,
+                beholdningListe,
+                afpHistorikk,
+                ufoereHistorikk,
+                erBrukergruppe4Eller5 = true
+            )
+        )
+    }
+}

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/merknad/MerknadAssemblerForBrukergruppe5.kt
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/merknad/MerknadAssemblerForBrukergruppe5.kt
@@ -1,0 +1,52 @@
+package no.nav.pensjon.selvbetjeningopptjening.merknad
+
+import no.nav.pensjon.selvbetjeningopptjening.opptjening.*
+import no.nav.pensjon.selvbetjeningopptjening.person.Person
+import org.springframework.stereotype.Component
+
+@Component
+class MerknadAssemblerForBrukergruppe5 : OpptjeningAssembler() {
+
+    fun merknader(person: Person, basis: OpptjeningBasis): Merknader =
+        merknader(
+            person,
+            beholdningListe = basis.pensjonsbeholdninger.orEmpty(),
+            restpensjonListe = basis.restpensjoner.orEmpty(),
+            inntektListe = basis.inntekter.orEmpty(),
+            afpHistorikk = basis.afpHistorikk,
+            ufoereHistorikk = basis.uforeHistorikk
+        )
+
+    fun merknader(
+        person: Person,
+        beholdningListe: List<Beholdning>,
+        restpensjonListe: List<Restpensjon>,
+        inntektListe: List<Inntekt>,
+        afpHistorikk: AfpHistorikk?,
+        ufoereHistorikk: UforeHistorikk?
+    ): Merknader {
+        val opptjeningPerAar = getOpptjeningerByYear(ArrayList<Pensjonspoeng?>(), restpensjonListe)
+        populatePensjonsbeholdning(opptjeningPerAar, getBeholdningerByYear(beholdningListe))
+
+        if (opptjeningPerAar.isEmpty())
+            return Merknader(perAar = emptyMap())
+
+        val inntektPerAar = getSumPensjonsgivendeInntekterByYear(inntektListe)
+        val foersteAar = getFirstYearWithOpptjening(person.getFodselsdato())
+        val sisteAar = findLatestOpptjeningYear(opptjeningPerAar)
+        setRestpensjoner(opptjeningPerAar, restpensjonListe)
+        removeFutureOpptjening(opptjeningPerAar, sisteAar)
+        putYearsWithAdditionalInntekt(inntektPerAar, opptjeningPerAar, foersteAar, sisteAar)
+        putYearsWithNoOpptjening(opptjeningPerAar, foersteAar, sisteAar)
+
+        return Merknader(
+            perAar = MerknadDeducer.merknaderPerAar(
+                opptjeningPerAar,
+                beholdningListe,
+                afpHistorikk,
+                ufoereHistorikk,
+                erBrukergruppe4Eller5 = true
+            )
+        )
+    }
+}

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/merknad/MerknadDeducer.kt
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/merknad/MerknadDeducer.kt
@@ -1,0 +1,102 @@
+package no.nav.pensjon.selvbetjeningopptjening.merknad
+
+import no.nav.pensjon.selvbetjeningopptjening.model.code.MerknadCode
+import no.nav.pensjon.selvbetjeningopptjening.opptjening.*
+import java.time.LocalDate
+
+object MerknadDeducer {
+
+    private const val REFORM_AAR = 2010
+
+    fun merknaderPerAar(
+        opptjeningPerAar: Map<Int, Opptjening>,
+        beholdningListe: List<Beholdning>,
+        afpHistorikk: AfpHistorikk?,
+        ufoereHistorikk: UforeHistorikk?,
+        erBrukergruppe4Eller5: Boolean
+    ): Map<Int, List<MerknadCode>> =
+        opptjeningPerAar.map { (aar, opptjening) ->
+            aar to merknadListe(
+                aar,
+                opptjening,
+                beholdningListe,
+                afpHistorikk,
+                ufoereHistorikk,
+                erBrukergruppe4Eller5
+            )
+        }.toMap()
+
+    private fun merknadListe(
+        aar: Int,
+        opptjening: Opptjening,
+        beholdningListe: List<Beholdning>,
+        afpHistorikk: AfpHistorikk?,
+        ufoereHistorikk: UforeHistorikk?,
+        erBrukergruppe4Eller5: Boolean
+    ): List<MerknadCode> {
+        val merknadListe = mutableListOf<MerknadCode>()
+        afpHistorikk?.let { afpMerknad(aar, historikk = it)?.let(merknadListe::add) }
+        ufoereHistorikk?.let { ufoeregradMerknad(aar, historikk = it)?.let(merknadListe::add) }
+        ingenOpptjeningMerknad(opptjening, merknadListe)?.let(merknadListe::add)
+
+        if (erBrukergruppe4Eller5) {
+            reformMerknad(aar)?.let(merknadListe::add)
+            omsorgsopptjeningMerknad(aar, opptjening, beholdningListe)?.let(merknadListe::add)
+            dagpengerMerknad(aar, beholdningListe)?.let(merknadListe::add)
+            foerstegangstjenesteMerknad(aar, beholdningListe)?.let(merknadListe::add)
+        }
+
+        return merknadListe
+    }
+
+    private fun afpMerknad(aar: Int, historikk: AfpHistorikk): MerknadCode? =
+        if (aar in historikk.startYear..sluttAar(historikk))
+            MerknadCode.AFP
+        else
+            null
+
+    private fun omsorgsopptjeningMerknad(
+        aar: Int,
+        opptjening: Opptjening,
+        beholdningListe: List<Beholdning>,
+    ): MerknadCode? =
+        if (opptjening.hasMerknad(MerknadCode.OMSORGSOPPTJENING).not() &&
+            beholdningListe.any { MerknadHandler.hasOmsorgsopptjening(aar, it) }
+        )
+            MerknadCode.OMSORGSOPPTJENING
+        else
+            null
+
+    private fun dagpengerMerknad(aar: Int, beholdningListe: List<Beholdning>): MerknadCode? =
+        if (beholdningListe.any { MerknadHandler.mottattDagpenger(aar, it) })
+            MerknadCode.DAGPENGER
+        else
+            null
+
+    private fun foerstegangstjenesteMerknad(aar: Int, beholdningListe: List<Beholdning>): MerknadCode? =
+        if (beholdningListe.any { MerknadHandler.mottattForstegangstjeneste(aar, it) })
+            MerknadCode.FORSTEGANGSTJENESTE
+        else
+            null
+
+    private fun ufoeregradMerknad(aar: Int, historikk: UforeHistorikk): MerknadCode? =
+        if ((MerknadHandler.getMaxUforegrad(aar, historikk) ?: 0) > 0)
+            MerknadCode.UFOREGRAD
+        else
+            null
+
+    private fun reformMerknad(aar: Int): MerknadCode? =
+        if (aar == REFORM_AAR)
+            MerknadCode.REFORM
+        else
+            null
+
+    private fun ingenOpptjeningMerknad(opptjening: Opptjening, merknadListe: List<MerknadCode>): MerknadCode? =
+        if (opptjening.isPositive || merknadListe.contains(MerknadCode.REFORM))
+            null
+        else
+            MerknadCode.INGEN_OPPTJENING
+
+    private fun sluttAar(historikk: AfpHistorikk): Int =
+        historikk.getEndYearOrDefault { LocalDate.now().year - 1 }
+}

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/merknad/MerknadDeducer.kt
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/merknad/MerknadDeducer.kt
@@ -37,7 +37,6 @@ object MerknadDeducer {
         val merknadListe = mutableListOf<MerknadCode>()
         afpHistorikk?.let { afpMerknad(aar, historikk = it)?.let(merknadListe::add) }
         ufoereHistorikk?.let { ufoeregradMerknad(aar, historikk = it)?.let(merknadListe::add) }
-        ingenOpptjeningMerknad(opptjening, merknadListe)?.let(merknadListe::add)
 
         if (erBrukergruppe4Eller5) {
             reformMerknad(aar)?.let(merknadListe::add)
@@ -46,6 +45,8 @@ object MerknadDeducer {
             foerstegangstjenesteMerknad(aar, beholdningListe)?.let(merknadListe::add)
         }
 
+        // NB: ingenOpptjeningMerknad must be after reformMerknad
+        ingenOpptjeningMerknad(opptjening, merknadListe)?.let(merknadListe::add)
         return merknadListe
     }
 

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/merknad/MerknadService.kt
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/merknad/MerknadService.kt
@@ -1,0 +1,88 @@
+package no.nav.pensjon.selvbetjeningopptjening.merknad
+
+import no.nav.pensjon.selvbetjeningopptjening.consumer.opptjeningsgrunnlag.OpptjeningsgrunnlagConsumer
+import no.nav.pensjon.selvbetjeningopptjening.consumer.pensjonsbeholdning.PensjonsbeholdningConsumer
+import no.nav.pensjon.selvbetjeningopptjening.consumer.pensjonspoeng.PensjonspoengConsumer
+import no.nav.pensjon.selvbetjeningopptjening.consumer.person.PersonConsumer
+import no.nav.pensjon.selvbetjeningopptjening.consumer.restpensjon.RestpensjonConsumer
+import no.nav.pensjon.selvbetjeningopptjening.consumer.uttaksgrad.UttaksgradGetter
+import no.nav.pensjon.selvbetjeningopptjening.gruppe.Brukergruppe
+import no.nav.pensjon.selvbetjeningopptjening.opptjening.*
+import no.nav.pensjon.selvbetjeningopptjening.person.Person
+import no.nav.pensjon.selvbetjeningopptjening.person.PersonService
+import no.nav.pensjon.selvbetjeningopptjening.person.group.UserGroupUtil.brukergruppe
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+
+/**
+ * Henter grunnlagsdata for merknader, og utleder merknader for hvert år med opptjening.
+ */
+@Service
+class MerknadService(
+    private val personService: PersonService,
+    private val personConsumer: PersonConsumer,
+    private val uttaksgradGetter: UttaksgradGetter,
+    private val opptjeningsgrunnlagConsumer: OpptjeningsgrunnlagConsumer,
+    private val pensjonsbeholdningConsumer: PensjonsbeholdningConsumer,
+    private val pensjonspoengConsumer: PensjonspoengConsumer,
+    private val restpensjonConsumer: RestpensjonConsumer
+) {
+    fun merknaderPerAar(pid: Pid): Merknader {
+        val person: Person = personService.getPerson(pid)!!
+        val fnr = pid.pid
+        val brukergruppe: Brukergruppe = brukergruppe(foedselsdato = person.getFodselsdato())
+        val uttaksgradListe: List<Uttaksgrad> = uttaksgradGetter.getAlderSakUttaksgradhistorikkForPerson(fnr).orEmpty()
+
+        return brukergruppe.merknadAssembler(
+            MerknadArguments(
+                person,
+                uttaksgradListe,
+                afpHistorikk = personConsumer.getAfpHistorikkForPerson(fnr),
+                ufoereHistorikk = personConsumer.getUforeHistorikkForPerson(fnr),
+                inntektListe = inntektListe(brukergruppe, person),
+                beholdningListe = beholdningListe(brukergruppe, pid),
+                pensjonspoengListe = pensjonspoengListe(brukergruppe, pid),
+                restpensjonListe = restpensjonListe(brukergruppe, uttaksgradListe, pid)
+            )
+        )
+    }
+
+    private fun inntektListe(brukergruppe: Brukergruppe, person: Person): List<Inntekt> =
+        if (brukergruppe.harInntekt)
+            opptjeningsgrunnlagConsumer.getInntektListeFromOpptjeningsgrunnlag(
+                person.pid.pid,
+                person.getFodselsdato().year + OPPTJENING_MINSTEALDER_AAR,
+                LocalDate.now().year
+            ).orEmpty()
+        else
+            emptyList()
+
+    private fun beholdningListe(brukergruppe: Brukergruppe, pid: Pid): List<Beholdning> =
+        if (brukergruppe.harBeholdning)
+            pensjonsbeholdningConsumer.getPensjonsbeholdning(pid.pid).orEmpty()
+        else
+            emptyList()
+
+    private fun pensjonspoengListe(brukergruppe: Brukergruppe, pid: Pid): List<Pensjonspoeng> =
+        if (brukergruppe.harPensjonspoeng)
+            pensjonspoengConsumer.getPensjonspoengListe(pid.pid).orEmpty()
+        else
+            emptyList()
+
+    private fun restpensjonListe(
+        brukergruppe: Brukergruppe,
+        uttaksgradListe: List<Uttaksgrad>,
+        pid: Pid
+    ): List<Restpensjon> =
+        if (shouldGetRestpensjon(brukergruppe, uttaksgradListe))
+            restpensjonConsumer.getRestpensjonListe(pid.pid).orEmpty()
+        else
+            emptyList()
+
+    companion object {
+        private const val OPPTJENING_MINSTEALDER_AAR = 13
+
+        private fun shouldGetRestpensjon(brukergruppe: Brukergruppe, uttaksgradListe: List<Uttaksgrad>): Boolean =
+            brukergruppe.harRestpensjon && uttaksgradListe.any { it.uttaksgrad < 100 }
+    }
+}

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/merknad/Merknader.kt
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/merknad/Merknader.kt
@@ -1,0 +1,7 @@
+package no.nav.pensjon.selvbetjeningopptjening.merknad
+
+import no.nav.pensjon.selvbetjeningopptjening.model.code.MerknadCode
+
+data class Merknader(
+    val perAar: Map<Int, List<MerknadCode>>
+)

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/model/code/UserGroup.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/model/code/UserGroup.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import static java.util.Collections.emptyList;
+import static no.nav.pensjon.selvbetjeningopptjening.opptjening.OpptjeningAssembler.getVedtakIdsForBeholdningAfter2009;
 
 public enum UserGroup {
 
@@ -30,18 +31,17 @@ public enum UserGroup {
         this.opptjeningAssembler = opptjeningAssembler;
     }
 
-    static OpptjeningResponse getOpptjeningForUserGroups123(OpptjeningArguments args) {
+    public static OpptjeningResponse getOpptjeningForUserGroups123(OpptjeningArguments args) {
         return getOpptjeningForUserGroups123(
                 args.getPerson(),
                 args.getRestpensjoner(),
                 args.getUttaksgrader(),
                 args.getAfpHistorikk(),
                 args.getUforeHistorikk(),
-                args.getPensjonspoengConsumer(),
-                args.getUttaksgradGetter());
+                args.getPensjonspoengConsumer());
     }
 
-    static OpptjeningResponse getOpptjeningForUserGroup4(OpptjeningArguments args) {
+    public static OpptjeningResponse getOpptjeningForUserGroup4(OpptjeningArguments args) {
         return getOpptjeningForUserGroup4(
                 args.getPerson(),
                 args.getRestpensjoner(),
@@ -53,7 +53,7 @@ public enum UserGroup {
                 args.getUttaksgradGetter());
     }
 
-    static OpptjeningResponse getOpptjeningForUserGroup5(OpptjeningArguments args) {
+    public static OpptjeningResponse getOpptjeningForUserGroup5(OpptjeningArguments args) {
         return getOpptjeningForUserGroup5(
                 args.getPerson(),
                 args.getRestpensjoner(),
@@ -70,8 +70,7 @@ public enum UserGroup {
                                                                     List<Uttaksgrad> uttaksgrader,
                                                                     AfpHistorikk afpHistorikk,
                                                                     UforeHistorikk uforeHistorikk,
-                                                                    PensjonspoengConsumer pensjonspoengConsumer,
-                                                                    UttaksgradGetter uttaksgradGetter) {
+                                                                    PensjonspoengConsumer pensjonspoengConsumer) {
         List<Pensjonspoeng> pensjonspoengList = pensjonspoengConsumer.getPensjonspoengListe(person.getPid().getPid());
 
         var basis = new OpptjeningBasis(
@@ -80,10 +79,11 @@ public enum UserGroup {
                 restpensjoner,
                 emptyList(), // No inntekter
                 uttaksgrader,
+                emptyList(),
                 afpHistorikk,
                 uforeHistorikk);
 
-        return new OpptjeningAssemblerForUserGroups123(uttaksgradGetter).createResponse(person, basis);
+        return new OpptjeningAssemblerForUserGroups123().createResponse(person, basis);
     }
 
     private static OpptjeningResponse getOpptjeningForUserGroup4(Person person,
@@ -97,6 +97,8 @@ public enum UserGroup {
         String pid = person.getPid().getPid();
         List<Beholdning> beholdninger = beholdningConsumer.getPensjonsbeholdning(pid);
         List<Pensjonspoeng> pensjonspoengList = pensjonspoengConsumer.getPensjonspoengListe(pid);
+        List<Long> vedtakIds = getVedtakIdsForBeholdningAfter2009(beholdninger);
+        List<Uttaksgrad> uttaksgraderForBeholdningAfter2009 = uttaksgradGetter.getUttaksgradForVedtak(vedtakIds);
 
         var basis = new OpptjeningBasis(
                 pensjonspoengList,
@@ -104,10 +106,11 @@ public enum UserGroup {
                 restpensjoner,
                 emptyList(), // No inntekter
                 uttaksgrader,
+                uttaksgraderForBeholdningAfter2009,
                 afpHistorikk,
                 uforeHistorikk);
 
-        return new OpptjeningAssemblerForUserGroup4(uttaksgradGetter).createResponse(person, basis);
+        return new OpptjeningAssemblerForUserGroup4().createResponse(person, basis);
     }
 
     private static OpptjeningResponse getOpptjeningForUserGroup5(Person person,
@@ -122,6 +125,8 @@ public enum UserGroup {
         List<Beholdning> beholdninger = beholdningConsumer.getPensjonsbeholdning(pid);
         int firstPossibleInntektYear = person.getFodselsdato().getYear() + 13;
         List<Inntekt> inntekter = opptjeningsgrunnlagConsumer.getInntektListeFromOpptjeningsgrunnlag(pid, firstPossibleInntektYear, LocalDate.now().getYear());
+        List<Long> vedtakIds = getVedtakIdsForBeholdningAfter2009(beholdninger);
+        List<Uttaksgrad> uttaksgraderForBeholdningAfter2009 = uttaksgradGetter.getUttaksgradForVedtak(vedtakIds);
 
         var basis = new OpptjeningBasis(
                 emptyList(), // No pensjonspoeng
@@ -129,10 +134,11 @@ public enum UserGroup {
                 restpensjoner,
                 inntekter,
                 uttaksgrader,
+                uttaksgraderForBeholdningAfter2009,
                 afpHistorikk,
                 uforeHistorikk);
 
-        return new OpptjeningAssemblerForUserGroup5(uttaksgradGetter).createResponse(person, basis);
+        return new OpptjeningAssemblerForUserGroup5().createResponse(person, basis);
     }
 
     public Function<OpptjeningArguments, OpptjeningResponse> getOpptjeningAssembler() {

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/Beholdning.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/Beholdning.java
@@ -251,7 +251,7 @@ public class Beholdning implements Periode {
         return grunnlagTypes.isEmpty() ? List.of(NO_GRUNNLAG) : grunnlagTypes;
     }
 
-    boolean isOmsorgGrunnlagForBeholdning() {
+    public boolean isOmsorgGrunnlagForBeholdning() {
         return grunnlag == omsorgsopptjening.getBelop();
     }
 

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/MerknadHandler.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/MerknadHandler.java
@@ -66,7 +66,7 @@ public class MerknadHandler {
                 .ifPresent(beholdning -> merknader.add(MerknadCode.FORSTEGANGSTJENESTE));
     }
 
-    private static boolean mottattDagpenger(int year, Beholdning beholdning) {
+    public static boolean mottattDagpenger(int year, Beholdning beholdning) {
         return (mottattDagpengerFiskere(beholdning) || mottattDagpenger(beholdning))
                 && year == beholdning.getDagpengeopptjening().getYear();
     }
@@ -82,7 +82,7 @@ public class MerknadHandler {
         return belop != null && belop.getOrdinartBelop() > 0;
     }
 
-    private static boolean mottattForstegangstjeneste(int year, Beholdning beholdning) {
+    public static boolean mottattForstegangstjeneste(int year, Beholdning beholdning) {
         Forstegangstjenesteopptjening belop = beholdning.getForstegangstjenesteopptjening();
 
         return belop != null
@@ -118,7 +118,7 @@ public class MerknadHandler {
         merknader.add(MerknadCode.UFOREGRAD);
     }
 
-    private static Integer getMaxUforegrad(int year, UforeHistorikk historikk) {
+    public static Integer getMaxUforegrad(int year, UforeHistorikk historikk) {
         Integer maxUforegrad = null;
 
         for (Uforeperiode periode : historikk.getUforeperioder()) {
@@ -170,7 +170,7 @@ public class MerknadHandler {
                 });
     }
 
-    private static boolean hasOmsorgsopptjening(int year, Beholdning beholdning) {
+    public static boolean hasOmsorgsopptjening(int year, Beholdning beholdning) {
         Omsorgsopptjening opptjening = beholdning.getOmsorgsopptjening();
 
         return opptjening != null

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/Opptjening.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/Opptjening.java
@@ -118,7 +118,7 @@ public class Opptjening {
         return merknader;
     }
 
-    boolean hasMerknad(MerknadCode value) {
+    public boolean hasMerknad(MerknadCode value) {
         return merknader.contains(value);
     }
 
@@ -132,6 +132,10 @@ public class Opptjening {
 
     public boolean hasPensjonsgivendeInntekt() {
         return hasPensjonsgivendeInntekt;
+    }
+
+    public boolean isPositive() {
+        return !isNotPositive();
     }
 
     boolean isNotPositive() {

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningArguments.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningArguments.java
@@ -19,15 +19,15 @@ public class OpptjeningArguments {
     private final PensjonsbeholdningConsumer beholdningConsumer;
     private final UttaksgradGetter uttaksgradGetter;
 
-    OpptjeningArguments(Person person,
-                        List<Restpensjon> restpensjoner,
-                        List<Uttaksgrad> uttaksgrader,
-                        AfpHistorikk afpHistorikk,
-                        UforeHistorikk uforeHistorikk,
-                        OpptjeningsgrunnlagConsumer opptjeningsgrunnlagConsumer,
-                        PensjonspoengConsumer pensjonspoengConsumer,
-                        PensjonsbeholdningConsumer beholdningConsumer,
-                        UttaksgradGetter uttaksgradGetter) {
+    public OpptjeningArguments(Person person,
+                               List<Restpensjon> restpensjoner,
+                               List<Uttaksgrad> uttaksgrader,
+                               AfpHistorikk afpHistorikk,
+                               UforeHistorikk uforeHistorikk,
+                               OpptjeningsgrunnlagConsumer opptjeningsgrunnlagConsumer,
+                               PensjonspoengConsumer pensjonspoengConsumer,
+                               PensjonsbeholdningConsumer beholdningConsumer,
+                               UttaksgradGetter uttaksgradGetter) {
         this.person = person;
         this.restpensjoner = restpensjoner;
         this.uttaksgrader = uttaksgrader;

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningAssembler.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningAssembler.java
@@ -1,6 +1,5 @@
 package no.nav.pensjon.selvbetjeningopptjening.opptjening;
 
-import no.nav.pensjon.selvbetjeningopptjening.consumer.uttaksgrad.UttaksgradGetter;
 import no.nav.pensjon.selvbetjeningopptjening.model.code.OpptjeningTypeCode;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.dto.OpptjeningDto;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.mapping.OpptjeningMapper;
@@ -20,38 +19,33 @@ import static no.nav.pensjon.selvbetjeningopptjening.opptjening.EndringPensjonsb
 import static no.nav.pensjon.selvbetjeningopptjening.util.Constants.REFORM_2010;
 import static no.nav.pensjon.selvbetjeningopptjening.util.DateUtil.firstDayOf;
 
-abstract class OpptjeningAssembler {
+public abstract class OpptjeningAssembler {
 
     private static final String INNTEKT_TYPE_SUM_PENSJONSGIVENDE_INNTEKT = "SUM_PI";
-    private final UttaksgradGetter uttaksgradGetter;
 
-    OpptjeningAssembler(UttaksgradGetter uttaksgradGetter) {
-        this.uttaksgradGetter = uttaksgradGetter;
-    }
-
-    Map<Integer, Opptjening> getOpptjeningerByYear(List<Pensjonspoeng> pensjonspoengList,
-                                                   List<Restpensjon> restpensjoner) {
+    public Map<Integer, Opptjening> getOpptjeningerByYear(List<Pensjonspoeng> pensjonspoengList,
+                                                          List<Restpensjon> restpensjoner) {
         Map<Integer, Opptjening> opptjeningerByYear = new HashMap<>();
         pensjonspoengList.forEach(poeng -> putOpptjeningYear(opptjeningerByYear, poeng.getYear()));
         restpensjoner.forEach(pensjon -> putOpptjeningYear(opptjeningerByYear, pensjon.getFomDate().getYear()));
         return opptjeningerByYear;
     }
 
-    Map<Integer, Long> getSumPensjonsgivendeInntekterByYear(List<Inntekt> inntekter) {
+    public Map<Integer, Long> getSumPensjonsgivendeInntekterByYear(List<Inntekt> inntekter) {
         return inntekter.stream()
                 .filter(inntekt -> INNTEKT_TYPE_SUM_PENSJONSGIVENDE_INNTEKT.equals(inntekt.getType()))
                 .collect(toMap(Inntekt::getYear, Inntekt::getBelop));
     }
 
-    void populatePensjonsbeholdning(Map<Integer, Opptjening> opptjeningerByYear,
-                                    Map<Integer, Beholdning> beholdningerByYear) {
+    public void populatePensjonsbeholdning(Map<Integer, Opptjening> opptjeningerByYear,
+                                           Map<Integer, Beholdning> beholdningerByYear) {
         beholdningerByYear.forEach((year, beholdning) -> populatePensjonsbeholdning(opptjeningerByYear, year, beholdning));
 
         beholdningerByYear.values().forEach(
                 beholdning -> setPensjonsgivendeInntektFromInntektopptjeningBelop(opptjeningerByYear, beholdning));
     }
 
-    Map<Integer, Beholdning> getBeholdningerByYear(List<Beholdning> beholdninger) {
+    public Map<Integer, Beholdning> getBeholdningerByYear(List<Beholdning> beholdninger) {
         if (beholdninger == null) {
             return emptyMap();
         }
@@ -65,7 +59,7 @@ abstract class OpptjeningAssembler {
         return beholdningerByYear;
     }
 
-    int getFirstYearWithOpptjening(LocalDate fodselsdato) {
+    public int getFirstYearWithOpptjening(LocalDate fodselsdato) {
         LocalDate firstYear = fodselsdato.plusYears(17);
 
         if (firstYear.isBefore(firstDayOf(1967))) {
@@ -93,7 +87,7 @@ abstract class OpptjeningAssembler {
         return fodselYear + 13;
     }
 
-    int findLatestOpptjeningYear(Map<Integer, Opptjening> opptjeningerByYear) {
+    public int findLatestOpptjeningYear(Map<Integer, Opptjening> opptjeningerByYear) {
         int lastYearWithOpptjening = -1;
         int thisYear = LocalDate.now().getYear();
 
@@ -106,11 +100,11 @@ abstract class OpptjeningAssembler {
         return lastYearWithOpptjening > -1 ? lastYearWithOpptjening : thisYear;
     }
 
-    void setRestpensjoner(Map<Integer, Opptjening> opptjeningerByYear, List<Restpensjon> restpensjoner) {
+    public void setRestpensjoner(Map<Integer, Opptjening> opptjeningerByYear, List<Restpensjon> restpensjoner) {
         restpensjoner.forEach(pensjon -> setRestpensjon(opptjeningerByYear, pensjon));
     }
 
-    void removeFutureOpptjening(Map<Integer, Opptjening> opptjeningerByYear, int latestOpptjeningYear) {
+    public void removeFutureOpptjening(Map<Integer, Opptjening> opptjeningerByYear, int latestOpptjeningYear) {
         List<Integer> yearsToBeRemoved = new ArrayList<>();
 
         for (Map.Entry<Integer, Opptjening> entries : opptjeningerByYear.entrySet()) {
@@ -127,17 +121,17 @@ abstract class OpptjeningAssembler {
     /**
      * Adds opptjening to opptjeningerByYear for years with inntekt but no beholdning.
      */
-    void putYearsWithAdditionalInntekt(Map<Integer, Long> inntekterByYear,
-                                       Map<Integer, Opptjening> opptjeningerByYear,
-                                       int firstYearWithOpptjening,
-                                       int lastYearWithOpptjening) {
+    public void putYearsWithAdditionalInntekt(Map<Integer, Long> inntekterByYear,
+                                              Map<Integer, Opptjening> opptjeningerByYear,
+                                              int firstYearWithOpptjening,
+                                              int lastYearWithOpptjening) {
         IntStream.rangeClosed(firstYearWithOpptjening, lastYearWithOpptjening)
                 .forEach(year -> putYearWithAdditionalInntekt(inntekterByYear, opptjeningerByYear, year));
     }
 
-    void putYearsWithNoOpptjening(Map<Integer, Opptjening> opptjeningerByYear,
-                                  int firstYearWithOpptjening,
-                                  int lastYearWithOpptjening) {
+    public void putYearsWithNoOpptjening(Map<Integer, Opptjening> opptjeningerByYear,
+                                         int firstYearWithOpptjening,
+                                         int lastYearWithOpptjening) {
         if (firstYearWithOpptjening <= 0 || lastYearWithOpptjening <= 0) {
             return;
         }
@@ -157,16 +151,14 @@ abstract class OpptjeningAssembler {
     }
 
     void setEndringerOpptjening(Map<Integer, Opptjening> opptjeningerByYear,
-                                List<Beholdning> beholdninger) {
-        List<Long> vedtakIds = getVedtakIdsForBeholdningAfter2009(beholdninger);
-        List<Uttaksgrad> uttaksgraderForBeholdningAfter2009 = uttaksgradGetter.getUttaksgradForVedtak(vedtakIds);
-
+                                List<Beholdning> beholdninger,
+                                List<Uttaksgrad> uttaksgraderForBeholdningAfter2009) {
         opptjeningerByYear.entrySet().stream()
                 .filter(entry -> entry.getKey() >= REFORM_2010)
                 .forEach(entry -> setEndringer(beholdninger, uttaksgraderForBeholdningAfter2009, entry.getKey(), entry.getValue()));
     }
 
-    void populatePensjonspoeng(Map<Integer, Opptjening> opptjeningerByYear, List<Pensjonspoeng> pensjonspoengList, List<Uttaksgrad> uttaksgrader) {
+    public void populatePensjonspoeng(Map<Integer, Opptjening> opptjeningerByYear, List<Pensjonspoeng> pensjonspoengList, List<Uttaksgrad> uttaksgrader) {
         pensjonspoengList.stream()
                 .filter(Pensjonspoeng::hasYear)
                 .forEach(poeng -> populatePensjonspoeng(opptjeningerByYear, poeng, uttaksgrader));
@@ -197,7 +189,7 @@ abstract class OpptjeningAssembler {
                 year, opptjening, beholdninger, uttaksgrader, afpHistorikk, uforeHistorikk);
     }
 
-    private static List<Long> getVedtakIdsForBeholdningAfter2009(List<Beholdning> beholdninger) {
+    public static List<Long> getVedtakIdsForBeholdningAfter2009(List<Beholdning> beholdninger) {
         return beholdninger.stream()
                 .filter(beholdning -> beholdning.hasVedtak() && beholdning.getFomDato().getYear() >= REFORM_2010 - 1)
                 .map(Beholdning::getVedtakId)

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningAssemblerForUserGroup4.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningAssemblerForUserGroup4.java
@@ -1,6 +1,5 @@
 package no.nav.pensjon.selvbetjeningopptjening.opptjening;
 
-import no.nav.pensjon.selvbetjeningopptjening.consumer.uttaksgrad.UttaksgradGetter;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.dto.OpptjeningResponse;
 import no.nav.pensjon.selvbetjeningopptjening.person.Person;
 
@@ -10,10 +9,6 @@ import java.util.Map;
 
 public class OpptjeningAssemblerForUserGroup4 extends OpptjeningAssembler {
 
-    public OpptjeningAssemblerForUserGroup4(UttaksgradGetter uttaksgradGetter /*, PidExtractor pidExtractor*/) {
-        super(uttaksgradGetter);
-    }
-
     public OpptjeningResponse createResponse(Person person, OpptjeningBasis basis) {
         return createResponse(
                 person,
@@ -21,6 +16,7 @@ public class OpptjeningAssemblerForUserGroup4 extends OpptjeningAssembler {
                 basis.getPensjonsbeholdninger(),
                 basis.getRestpensjoner(),
                 basis.getUttaksgrader(),
+                basis.getUttaksgraderForBeholdningAfter2009(),
                 basis.getAfpHistorikk(),
                 basis.getUforeHistorikk());
     }
@@ -30,6 +26,7 @@ public class OpptjeningAssemblerForUserGroup4 extends OpptjeningAssembler {
                                               List<Beholdning> beholdninger,
                                               List<Restpensjon> restpensjoner,
                                               List<Uttaksgrad> uttaksgrader,
+                                              List<Uttaksgrad> uttaksgraderForBeholdningAfter2009,
                                               AfpHistorikk afpHistorikk,
                                               UforeHistorikk uforeHistorikk) {
         LocalDate fodselsdato = person.getFodselsdato();
@@ -50,7 +47,7 @@ public class OpptjeningAssemblerForUserGroup4 extends OpptjeningAssembler {
         putYearsWithNoOpptjening(opptjeningerByYear, firstYearWithOpptjening, lastYearWithOpptjening);
         populateMerknadForOpptjening(opptjeningerByYear, beholdninger, uttaksgrader, afpHistorikk, uforeHistorikk);
         int numberOfYearsWithPensjonspoeng = countNumberOfYearsWithPensjonspoeng(opptjeningerByYear);
-        setEndringerOpptjening(opptjeningerByYear, beholdninger);
+        setEndringerOpptjening(opptjeningerByYear, beholdninger, uttaksgraderForBeholdningAfter2009);
         response.setNumberOfYearsWithPensjonspoeng(numberOfYearsWithPensjonspoeng);
         response.setOpptjeningData(toDto(opptjeningerByYear));
         return response;

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningAssemblerForUserGroup5.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningAssemblerForUserGroup5.java
@@ -1,6 +1,5 @@
 package no.nav.pensjon.selvbetjeningopptjening.opptjening;
 
-import no.nav.pensjon.selvbetjeningopptjening.consumer.uttaksgrad.UttaksgradGetter;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.dto.OpptjeningResponse;
 import no.nav.pensjon.selvbetjeningopptjening.person.Person;
 
@@ -11,10 +10,6 @@ import java.util.Map;
 public class OpptjeningAssemblerForUserGroup5 extends OpptjeningAssembler {
     private static final int ANDEL_PENSJON_BASERT_PA_BEHOLDNING_USERGROUP5 = 10;
 
-    public OpptjeningAssemblerForUserGroup5(UttaksgradGetter uttaksgradGetter) {
-        super(uttaksgradGetter);
-    }
-
     public OpptjeningResponse createResponse(Person person, OpptjeningBasis basis) {
         return createResponse(
                 person,
@@ -22,6 +17,7 @@ public class OpptjeningAssemblerForUserGroup5 extends OpptjeningAssembler {
                 basis.getRestpensjoner(),
                 basis.getInntekter(),
                 basis.getUttaksgrader(),
+                basis.getUttaksgraderForBeholdningAfter2009(),
                 basis.getAfpHistorikk(),
                 basis.getUforeHistorikk());
     }
@@ -31,6 +27,7 @@ public class OpptjeningAssemblerForUserGroup5 extends OpptjeningAssembler {
                                               List<Restpensjon> restpensjoner,
                                               List<Inntekt> inntekter,
                                               List<Uttaksgrad> uttaksgrader,
+                                              List<Uttaksgrad> uttaksgraderForBeholdningAfter2009,
                                               AfpHistorikk afpHistorikk,
                                               UforeHistorikk uforeHistorikk) {
         OpptjeningResponse response = new OpptjeningResponse(person, ANDEL_PENSJON_BASERT_PA_BEHOLDNING_USERGROUP5, person.getPid().getPid(), getFullmektigPid());
@@ -49,7 +46,7 @@ public class OpptjeningAssemblerForUserGroup5 extends OpptjeningAssembler {
         putYearsWithAdditionalInntekt(inntekterByYear, opptjeningerByYear, firstYearWithOpptjening, lastYearWithOpptjening);
         putYearsWithNoOpptjening(opptjeningerByYear, firstYearWithOpptjening, lastYearWithOpptjening);
         populateMerknadForOpptjening(opptjeningerByYear, beholdninger, uttaksgrader, afpHistorikk, uforeHistorikk);
-        setEndringerOpptjening(opptjeningerByYear, beholdninger);
+        setEndringerOpptjening(opptjeningerByYear, beholdninger, uttaksgraderForBeholdningAfter2009);
         response.setOpptjeningData(toDto(opptjeningerByYear));
         return response;
     }

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningAssemblerForUserGroups123.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningAssemblerForUserGroups123.java
@@ -1,6 +1,5 @@
 package no.nav.pensjon.selvbetjeningopptjening.opptjening;
 
-import no.nav.pensjon.selvbetjeningopptjening.consumer.uttaksgrad.UttaksgradGetter;
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.dto.OpptjeningResponse;
 import no.nav.pensjon.selvbetjeningopptjening.person.Person;
 
@@ -9,10 +8,6 @@ import java.util.Map;
 
 public class OpptjeningAssemblerForUserGroups123 extends OpptjeningAssembler {
     private static final int ANDEL_PENSJON_BASERT_PA_BEHOLDNING_USERGROUPS123 = 0;
-
-    public OpptjeningAssemblerForUserGroups123(UttaksgradGetter uttaksgradGetter) {
-        super(uttaksgradGetter);
-    }
 
     public OpptjeningResponse createResponse(Person person, OpptjeningBasis basis) {
         return createResponse(

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningBasis.java
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningBasis.java
@@ -9,6 +9,7 @@ public class OpptjeningBasis {
     private final List<Restpensjon> restpensjoner;
     private final List<Inntekt> inntekter;
     private final List<Uttaksgrad> uttaksgrader;
+    private final List<Uttaksgrad> uttaksgraderForBeholdningAfter2009;
     private final AfpHistorikk afpHistorikk;
     private final UforeHistorikk uforeHistorikk;
 
@@ -17,6 +18,7 @@ public class OpptjeningBasis {
                            List<Restpensjon> restpensjoner,
                            List<Inntekt> inntekter,
                            List<Uttaksgrad> uttaksgrader,
+                           List<Uttaksgrad> uttaksgraderForBeholdningAfter2009,
                            AfpHistorikk afpHistorikk,
                            UforeHistorikk uforeHistorikk) {
         this.pensjonspoengList = pensjonspoengList;
@@ -24,35 +26,40 @@ public class OpptjeningBasis {
         this.restpensjoner = restpensjoner;
         this.inntekter = inntekter;
         this.uttaksgrader = uttaksgrader;
+        this.uttaksgraderForBeholdningAfter2009 = uttaksgraderForBeholdningAfter2009;
         this.afpHistorikk = afpHistorikk;
         this.uforeHistorikk = uforeHistorikk;
     }
 
-    List<Pensjonspoeng> getPensjonspoengList() {
+    public List<Pensjonspoeng> getPensjonspoengList() {
         return pensjonspoengList;
     }
 
-    List<Beholdning> getPensjonsbeholdninger() {
+    public List<Beholdning> getPensjonsbeholdninger() {
         return beholdninger;
     }
 
-    List<Restpensjon> getRestpensjoner() {
+    public List<Restpensjon> getRestpensjoner() {
         return restpensjoner;
     }
 
-    List<Inntekt> getInntekter() {
+    public List<Inntekt> getInntekter() {
         return inntekter;
     }
 
-    List<Uttaksgrad> getUttaksgrader() {
+    public List<Uttaksgrad> getUttaksgrader() {
         return uttaksgrader;
     }
 
-    AfpHistorikk getAfpHistorikk() {
+    public List<Uttaksgrad> getUttaksgraderForBeholdningAfter2009() {
+        return uttaksgraderForBeholdningAfter2009;
+    }
+
+    public AfpHistorikk getAfpHistorikk() {
         return afpHistorikk;
     }
 
-    UforeHistorikk getUforeHistorikk() {
+    public UforeHistorikk getUforeHistorikk() {
         return uforeHistorikk;
     }
 }

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/person/group/UserGroupUtil.kt
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/person/group/UserGroupUtil.kt
@@ -1,6 +1,7 @@
 package no.nav.pensjon.selvbetjeningopptjening.person.group
 
 import io.micrometer.core.instrument.Metrics
+import no.nav.pensjon.selvbetjeningopptjening.gruppe.Brukergruppe
 import no.nav.pensjon.selvbetjeningopptjening.model.code.UserGroup
 import java.time.LocalDate
 import java.time.Month
@@ -27,6 +28,9 @@ object UserGroupUtil {
      * The last birthyear that has "overgangsregler for opptjening"
      */
     private const val LAST_BIRTHYEAR_WITH_OVERGANGSREGLER: Int = 1962
+
+    fun brukergruppe(foedselsdato: LocalDate): Brukergruppe =
+        brukergruppe(kalenderaar = foedselsdato.year, kalendermaaned = foedselsdato.month)
 
     fun findUserGroup(birthDate: LocalDate): UserGroup =
         findUserGroup(birthDate.year, birthDate.month)
@@ -56,6 +60,22 @@ object UserGroupUtil {
         incrementCounter("Født etter 1962")
         return UserGroup.USER_GROUP_5
     }
+
+    private fun brukergruppe(kalenderaar: Int, kalendermaaned: Month): Brukergruppe =
+        when {
+            kalenderaar < FIRST_BIRTHYEAR_WITH_NEW_ALDER -> Brukergruppe.EN
+            kalenderaar <= FIRST_BIRTHYEAR_WITH_NEW_PRIVAT_AFP ->
+                if (kalenderaar == FIRST_BIRTHYEAR_WITH_NEW_PRIVAT_AFP && kalendermaaned == Month.DECEMBER)
+                    Brukergruppe.TRE
+                else
+                    Brukergruppe.TO
+
+            kalenderaar < FIRST_BIRTHYEAR_WITH_OVERGANGSREGLER -> Brukergruppe.TRE
+            kalenderaar <= LAST_BIRTHYEAR_WITH_OVERGANGSREGLER -> Brukergruppe.FIRE
+            else -> Brukergruppe.FEM
+        }.also {
+            incrementCounter(it.aldersbeskrivelse)
+        }
 
     private fun incrementCounter(group: String) {
         Metrics.counter("pensjon_selvbetjening_user_group_counter", "user-group", group).increment()

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/tech/security/SpringSecurityConfiguration.kt
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/tech/security/SpringSecurityConfiguration.kt
@@ -22,10 +22,10 @@ import org.springframework.security.web.authentication.www.BasicAuthenticationFi
 import kotlin.apply
 
 @Configuration
-open class SpringSecurityConfiguration {
+class SpringSecurityConfiguration {
 
     @Bean
-    open fun filterChain(
+    fun filterChain(
         http: HttpSecurity,
         authResolver: AuthenticationManagerResolver<HttpServletRequest>,
         securityContextEnricher: SecurityContextEnricher
@@ -57,22 +57,22 @@ open class SpringSecurityConfiguration {
             .build()
 
     @Bean
-    open fun tokenAuthenticationManagerResolver(
+    fun tokenAuthenticationManagerResolver(
         @Qualifier("combo-provider") universalProviderManager: ProviderManager
     ): AuthenticationManagerResolver<HttpServletRequest> =
         AuthenticationManagerResolver { universalProviderManager }
 
     @Bean("combo-provider")
     @Primary
-    open fun comboProvider(
-        @Value("\${id-porten.issuer}") idPortenIssuer: String,
-        @Value("\${id-porten.audience}") idPortenAudience: String,
-        @Value("\${token-x.issuer}") tokenXIssuer: String,
-        @Value("\${token-x.client.id}") tokenXClientId: String,
-        @Value("\${azure-app.issuer}") entraIdIssuer: String,
-        // Use sob.frontend.client-id until frontend exchanges Entra token into OBO token:
-        //@Value("\${azure-app.client-id}") entraIdClientId: String
-        @Value("\${sob.frontend.client-id}") entraIdClientId: String
+    fun comboProvider(
+        @Value($$"${id-porten.issuer}") idPortenIssuer: String,
+        @Value($$"${id-porten.audience}") idPortenAudience: String,
+        @Value($$"${token-x.issuer}") tokenXIssuer: String,
+        @Value($$"${token-x.client.id}") tokenXClientId: String,
+        @Value($$"${azure-app.issuer}") entraIdIssuer: String,
+        @Value($$"${azure-app.client-id}") entraIdClientId: String,
+        // Needed until frontend exchanges Entra token into OBO token:
+        @Value($$"${sob.frontend.client-id}") entraIdClientId2: String
     ): ProviderManager =
         ProviderManager(
             JwtAuthenticationProvider(
@@ -82,7 +82,7 @@ open class SpringSecurityConfiguration {
                 jwtDecoder(tokenXIssuer, tokenValidator = TokenAudienceValidator(tokenXClientId))
             ),
             JwtAuthenticationProvider(
-                jwtDecoder(entraIdIssuer, tokenValidator = TokenAudienceValidator(entraIdClientId))
+                jwtDecoder(entraIdIssuer, tokenValidator = TokenAudienceValidator(entraIdClientId, entraIdClientId2))
             )
         )
 

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/tech/security/ingress/TokenAudienceValidator.kt
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/tech/security/ingress/TokenAudienceValidator.kt
@@ -11,7 +11,7 @@ import kotlin.collections.joinToString
 import kotlin.collections.orEmpty
 import kotlin.let
 
-class TokenAudienceValidator(val audience: String) : OAuth2TokenValidator<Jwt> {
+class TokenAudienceValidator(val audience: String, val audience2: String? = null) : OAuth2TokenValidator<Jwt> {
 
     private val log = KotlinLogging.logger {}
 
@@ -19,7 +19,7 @@ class TokenAudienceValidator(val audience: String) : OAuth2TokenValidator<Jwt> {
         validate(token.audience.orEmpty())
 
     private fun validate(audiences: List<String>): OAuth2TokenValidatorResult =
-        if (audiences.contains(audience))
+        if (audiences.contains(audience) || audience2?.let(audiences::contains) == true)
             success()
         else
             "Invalid audience claim: ${audiences.joinToString()}".let {

--- a/src/main/java/no/nav/pensjon/selvbetjeningopptjening/tech/security/ingress/impersonal/ImpersonalAccessFilter.kt
+++ b/src/main/java/no/nav/pensjon/selvbetjeningopptjening/tech/security/ingress/impersonal/ImpersonalAccessFilter.kt
@@ -10,11 +10,13 @@ import no.nav.pensjon.selvbetjeningopptjening.common.exception.NotFoundException
 import no.nav.pensjon.selvbetjeningopptjening.tech.security.ingress.TargetPidExtractor
 import no.nav.pensjon.selvbetjeningopptjening.tech.security.ingress.impersonal.audit.Auditor
 import no.nav.pensjon.selvbetjeningopptjening.tech.security.ingress.impersonal.group.GroupMembershipService
+import no.nav.pensjon.selvbetjeningopptjening.tech.security.ingress.jwt.SecurityContextClaimExtractor
 import no.nav.pensjon.selvbetjeningopptjening.tech.web.CustomHttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import org.springframework.util.StringUtils.hasLength
 import org.springframework.web.filter.GenericFilterBean
+import kotlin.collections.orEmpty
 
 @Component
 class ImpersonalAccessFilter(
@@ -28,9 +30,10 @@ class ImpersonalAccessFilter(
     override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
         if (hasPid(request as HttpServletRequest)) {
             val pid = pidGetter.pid()
+            val personalAccess = accessAsApplication().not()
 
             try {
-                if (!groupMembershipService.innloggetBrukerHarTilgang(pid)) {
+                if (personalAccess && groupMembershipService.innloggetBrukerHarTilgang(pid).not()) {
                     forbidden(response as HttpServletResponse)
                     return
                 }
@@ -39,11 +42,16 @@ class ImpersonalAccessFilter(
                 return
             }
 
-            auditor.audit(pid, request.requestURI)
+            if (personalAccess) {
+                auditor.audit(onBehalfOfPid = pid, requestUri = request.requestURI)
+            }
         }
 
         chain.doFilter(request, response)
     }
+
+    private fun accessAsApplication(): Boolean =
+        rolesFromSecurityContext()?.map { it.toString() }.orEmpty().contains("access_as_application")
 
     private fun hasPid(request: HttpServletRequest): Boolean =
         hasLength(request.getHeader(CustomHttpHeaders.PID))
@@ -61,5 +69,11 @@ class ImpersonalAccessFilter(
             log.info { it }
             response.sendError(HttpStatus.NOT_FOUND.value(), it)
         }
+    }
+
+    private companion object {
+        private const val CLAIM_KEY = "roles"
+
+        private fun rolesFromSecurityContext() = SecurityContextClaimExtractor.claim(CLAIM_KEY) as? List<*>
     }
 }

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/api/merknad/v1/acl/MerknadMapperTest.kt
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/api/merknad/v1/acl/MerknadMapperTest.kt
@@ -1,0 +1,26 @@
+package no.nav.pensjon.selvbetjeningopptjening.api.merknad.v1.acl
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import no.nav.pensjon.selvbetjeningopptjening.merknad.Merknader
+import no.nav.pensjon.selvbetjeningopptjening.model.code.MerknadCode
+
+class MerknadMapperTest : ShouldSpec({
+
+    should("map from domain representation to transferable representation") {
+        MerknadMapper.transferable(
+            Merknader(
+                perAar = mapOf(
+                    2001 to listOf(MerknadCode.INGEN_OPPTJENING),
+                    2002 to listOf(MerknadCode.AFP, MerknadCode.DAGPENGER)
+                )
+            )
+        ) shouldBe
+                MerknaderV1(
+                    merknaderPerAar = mapOf(
+                        2001 to listOf(MerknadCodeV1.INGEN_OPPTJENING),
+                        2002 to listOf(MerknadCodeV1.AFP, MerknadCodeV1.DAGPENGER)
+                    )
+                )
+    }
+})

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/merknad/MerknadDeducerTest.kt
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/merknad/MerknadDeducerTest.kt
@@ -1,0 +1,156 @@
+package no.nav.pensjon.selvbetjeningopptjening.merknad
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import no.nav.pensjon.selvbetjeningopptjening.mock.TestObjects.beholdning
+import no.nav.pensjon.selvbetjeningopptjening.model.code.MerknadCode
+import no.nav.pensjon.selvbetjeningopptjening.model.code.UforeTypeCode
+import no.nav.pensjon.selvbetjeningopptjening.opptjening.*
+import java.time.LocalDate
+
+class MerknadDeducerTest : ShouldSpec({
+
+    context("ingen opptjening") {
+        should("gi merknad 'ingen opptjening'") {
+            MerknadDeducer.merknaderPerAar(
+                opptjeningPerAar = ingenOpptjening(aar = 2026),
+                beholdningListe = emptyList(),
+                afpHistorikk = null,
+                ufoereHistorikk = null,
+                erBrukergruppe4Eller5 = false
+            ) shouldBe mapOf(2026 to listOf(MerknadCode.INGEN_OPPTJENING))
+        }
+
+        context("reformår, brukergruppe 4 eller 5") {
+            should("utelate merknad 'ingen opptjening'") {
+                MerknadDeducer.merknaderPerAar(
+                    opptjeningPerAar = ingenOpptjening(aar = 2010), // reformår
+                    beholdningListe = emptyList(),
+                    afpHistorikk = null,
+                    ufoereHistorikk = null,
+                    erBrukergruppe4Eller5 = true
+                ) shouldBe mapOf(2010 to listOf(MerknadCode.REFORM))
+            }
+        }
+    }
+
+    context("har AFP i opptjeningsperioden") {
+        should("gi merknad 'AFP'") {
+            MerknadDeducer.merknaderPerAar(
+                opptjeningPerAar = opptjening(aar = 2026),
+                beholdningListe = emptyList(),
+                afpHistorikk = AfpHistorikk(
+                    virkningFomDate = LocalDate.of(2026, 1, 1),
+                    virkningTomDate = LocalDate.of(2030, 12, 31)
+                ),
+                ufoereHistorikk = null,
+                erBrukergruppe4Eller5 = false
+            ) shouldBe mapOf(2026 to listOf(MerknadCode.AFP))
+        }
+    }
+
+    context("har uføregrad i opptjeningsperioden") {
+        should("gi merknad 'uføregrad'") {
+            MerknadDeducer.merknaderPerAar(
+                opptjeningPerAar = opptjening(aar = 2026),
+                beholdningListe = emptyList(),
+                afpHistorikk = null,
+                ufoereHistorikk = UforeHistorikk(
+                    listOf(
+                        Uforeperiode(
+                            1,
+                            UforeTypeCode.UFORE,
+                            LocalDate.of(2026, 1, 1),
+                            LocalDate.of(2030, 12, 31)
+                        )
+                    )
+                ),
+                erBrukergruppe4Eller5 = false
+            ) shouldBe mapOf(2026 to listOf(MerknadCode.UFOREGRAD))
+        }
+    }
+
+    context("brukergruppe 1, 2 eller 3") {
+        should("ikke gi merknad 'reform' for 2010") {
+            MerknadDeducer.merknaderPerAar(
+                opptjeningPerAar = opptjening(aar = 2010),
+                beholdningListe = emptyList(),
+                afpHistorikk = null,
+                ufoereHistorikk = null,
+                erBrukergruppe4Eller5 = false
+            ) shouldBe mapOf(2010 to emptyList())
+        }
+    }
+
+    context("brukergruppe 4 eller 5") {
+        should("gi merknad 'reform' for 2010") {
+            MerknadDeducer.merknaderPerAar(
+                opptjeningPerAar = opptjening(aar = 2010),
+                beholdningListe = emptyList(),
+                afpHistorikk = null,
+                ufoereHistorikk = null,
+                erBrukergruppe4Eller5 = true
+            ) shouldBe mapOf(2010 to listOf(MerknadCode.REFORM))
+        }
+
+        context("har omsorgsopptjening i opptjeningsperioden") {
+            should("gi merknad 'omsorgsopptjening'") {
+                MerknadDeducer.merknaderPerAar(
+                    opptjeningPerAar = opptjening(aar = 2026),
+                    beholdningListe = listOf(beholdning(aar = 2026, omsorgsopptjening = 123.4)),
+                    afpHistorikk = null,
+                    ufoereHistorikk = null,
+                    erBrukergruppe4Eller5 = true
+                ) shouldBe mapOf(2026 to listOf(MerknadCode.OMSORGSOPPTJENING))
+            }
+        }
+
+        context("har ordinære dagpenger i opptjeningsperioden") {
+            should("gi merknad 'dagpenger'") {
+                MerknadDeducer.merknaderPerAar(
+                    opptjeningPerAar = opptjening(aar = 2026),
+                    beholdningListe = listOf(
+                        beholdning(aar = 2026, ordinaerDagpengeopptjening = 123.4)
+                    ),
+                    afpHistorikk = null,
+                    ufoereHistorikk = null,
+                    erBrukergruppe4Eller5 = true
+                ) shouldBe mapOf(2026 to listOf(MerknadCode.DAGPENGER))
+            }
+        }
+
+        context("har dagpenger som fisker i opptjeningsperioden") {
+            should("gi merknad 'dagpenger'") {
+                MerknadDeducer.merknaderPerAar(
+                    opptjeningPerAar = opptjening(aar = 2026),
+                    beholdningListe = listOf(
+                        beholdning(aar = 2026, fiskerDagpengeopptjening = 123.4)
+                    ),
+                    afpHistorikk = null,
+                    ufoereHistorikk = null,
+                    erBrukergruppe4Eller5 = true
+                ) shouldBe mapOf(2026 to listOf(MerknadCode.DAGPENGER))
+            }
+        }
+
+        context("har førstegangstjeneste i opptjeningsperioden") {
+            should("gi merknad 'førstegangstjeneste'") {
+                MerknadDeducer.merknaderPerAar(
+                    opptjeningPerAar = opptjening(aar = 2025),
+                    beholdningListe = listOf(
+                        beholdning(aar = 2025, foerstegangstjenesteopptjening = 123.4)
+                    ),
+                    afpHistorikk = null,
+                    ufoereHistorikk = null,
+                    erBrukergruppe4Eller5 = true
+                ) shouldBe mapOf(2025 to listOf(MerknadCode.FORSTEGANGSTJENESTE))
+            }
+        }
+    }
+})
+
+private fun opptjening(aar: Int): Map<Int, Opptjening> =
+    mapOf(aar to Opptjening(111000L, 2.3))
+
+private fun ingenOpptjening(aar: Int): Map<Int, Opptjening> =
+    mapOf(aar to Opptjening(0, 0.0))

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/merknad/MerknadServiceTest.kt
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/merknad/MerknadServiceTest.kt
@@ -1,0 +1,87 @@
+package no.nav.pensjon.selvbetjeningopptjening.merknad
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.pensjon.selvbetjeningopptjening.consumer.opptjeningsgrunnlag.OpptjeningsgrunnlagConsumer
+import no.nav.pensjon.selvbetjeningopptjening.consumer.pensjonsbeholdning.PensjonsbeholdningConsumer
+import no.nav.pensjon.selvbetjeningopptjening.consumer.person.PersonConsumer
+import no.nav.pensjon.selvbetjeningopptjening.mock.TestObjects.beholdning
+import no.nav.pensjon.selvbetjeningopptjening.mock.TestObjects.pid
+import no.nav.pensjon.selvbetjeningopptjening.model.code.MerknadCode
+import no.nav.pensjon.selvbetjeningopptjening.opptjening.AfpHistorikk
+import no.nav.pensjon.selvbetjeningopptjening.opptjening.Inntekt
+import no.nav.pensjon.selvbetjeningopptjening.person.Foedselsdato2
+import no.nav.pensjon.selvbetjeningopptjening.person.Person
+import no.nav.pensjon.selvbetjeningopptjening.person.PersonService
+import java.time.LocalDate
+
+class MerknadServiceTest : ShouldSpec({
+
+    context("opptjening mulig f.o.m. 2024, har AFP i 2025") {
+        should("gi merknadene 'ingen opptjening' for 2024, 'AFP' for 2025") {
+            MerknadService(
+                personService = arrangePerson(), // født 2011 => opptjening mulig f.o.m. 2024
+                personConsumer = arrangeAfp(), // har AFP i 2025
+                uttaksgradGetter = mockk(relaxed = true),
+                opptjeningsgrunnlagConsumer = arrangeInntekt(),
+                pensjonsbeholdningConsumer = arrangeBeholdning(), // har beholdning (dvs. opptjening) i 2025
+                pensjonspoengConsumer = mockk(),
+                restpensjonConsumer = mockk()
+            ).merknaderPerAar(pid) shouldBe
+                    Merknader(
+                        perAar = mapOf(
+                            2024 to listOf(MerknadCode.INGEN_OPPTJENING),
+                            2025 to listOf(MerknadCode.AFP)
+                        )
+                    )
+        }
+    }
+})
+
+/**
+ * AFP i 2025
+ */
+private fun arrangeAfp(): PersonConsumer =
+    mockk(relaxed = true) {
+        every {
+            getAfpHistorikkForPerson(any())
+        } returns AfpHistorikk(
+            virkningFomDate = LocalDate.of(2025, 1, 1),
+            virkningTomDate = LocalDate.of(2030, 12, 31)
+        )
+    }
+
+/**
+ * Beholdning (dvs. opptjening) i 2025
+ */
+private fun arrangeBeholdning(): PensjonsbeholdningConsumer =
+    mockk {
+        every {
+            getPensjonsbeholdning(any())
+        } returns listOf(beholdning(aar = 2025))
+    }
+
+private fun arrangeInntekt(): OpptjeningsgrunnlagConsumer =
+    mockk {
+        every {
+            getInntektListeFromOpptjeningsgrunnlag(any(), any(), any())
+        } returns listOf(Inntekt(2025, "T", 111000L))
+    }
+
+private fun arrangePerson(): PersonService =
+    mockk {
+        every {
+            getPerson(any())
+        } returns Person(
+            pid = pid,
+            fornavn = "F",
+            mellomnavn = "M",
+            etternavn = "E",
+            foedselsdato = Foedselsdato2(
+                value = LocalDate.of(2011, 3, 4),
+                basedOnYearOnly = false
+            )
+        )
+    }

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/mock/TestObjects.kt
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/mock/TestObjects.kt
@@ -6,10 +6,9 @@ import no.nav.pensjon.selvbetjeningopptjening.opptjening.Pid
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.UforeHistorikk
 import org.springframework.security.oauth2.jwt.Jwt
 import java.time.LocalDate
-import kotlin.to
 
 object TestObjects {
-    val jwt = Jwt("j.w.t", null, null, mapOf("k" to "v"), mapOf("k" to "v"))
+    val jwt = jwt(claims = mapOf("k" to "v"))
 
     val pid = Pid("22925399748")
 
@@ -20,7 +19,17 @@ object TestObjects {
             emptyList(),
             emptyList(),
             emptyList(),
+            emptyList(),
             AfpHistorikk(LocalDate.of(2021, 1, 1), null),
             UforeHistorikk(emptyList())
+        )
+
+    fun jwt(claims: Map<String, Any>) =
+        Jwt(
+            "j.w.t",
+            null,
+            null,
+            mapOf("k" to "v"),
+            claims
         )
 }

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/mock/TestObjects.kt
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/mock/TestObjects.kt
@@ -1,6 +1,10 @@
 package no.nav.pensjon.selvbetjeningopptjening.mock
 
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.AfpHistorikk
+import no.nav.pensjon.selvbetjeningopptjening.opptjening.Beholdning
+import no.nav.pensjon.selvbetjeningopptjening.opptjening.Dagpengeopptjening
+import no.nav.pensjon.selvbetjeningopptjening.opptjening.Forstegangstjenesteopptjening
+import no.nav.pensjon.selvbetjeningopptjening.opptjening.Omsorgsopptjening
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.OpptjeningBasis
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.Pid
 import no.nav.pensjon.selvbetjeningopptjening.opptjening.UforeHistorikk
@@ -22,6 +26,36 @@ object TestObjects {
             emptyList(),
             AfpHistorikk(LocalDate.of(2021, 1, 1), null),
             UforeHistorikk(emptyList())
+        )
+
+    fun beholdning(
+        aar: Int,
+        ordinaerDagpengeopptjening: Double? = null,
+        fiskerDagpengeopptjening: Double? = null,
+        foerstegangstjenesteopptjening: Double? = null,
+        omsorgsopptjening: Double? = null
+    ) =
+        Beholdning(
+            1,
+            pid.pid,
+            "S",
+            "T",
+            1.2,
+            2,
+            LocalDate.of(aar, 1, 1),
+            LocalDate.of(aar, 12, 31),
+            2.3,
+            2.2,
+            3.4,
+            3.3,
+            "Å",
+            null,
+            null,
+            omsorgsopptjening?.let { Omsorgsopptjening(aar, it, null) },
+            ordinaerDagpengeopptjening?.let { Dagpengeopptjening(aar, it, null) }
+                ?: fiskerDagpengeopptjening?.let { Dagpengeopptjening(aar, null, it) },
+            foerstegangstjenesteopptjening?.let { Forstegangstjenesteopptjening(aar, it) },
+            null
         )
 
     fun jwt(claims: Map<String, Any>) =

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningAssemblerForUserGroup123Test.kt
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningAssemblerForUserGroup123Test.kt
@@ -2,7 +2,6 @@ package no.nav.pensjon.selvbetjeningopptjening.opptjening
 
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
-import io.mockk.mockk
 import no.nav.pensjon.selvbetjeningopptjening.PidGenerator.generatePidAtAge
 import no.nav.pensjon.selvbetjeningopptjening.mock.TestObjects.emptyOpptjeningBasis
 import no.nav.pensjon.selvbetjeningopptjening.person.Foedselsdato2
@@ -15,7 +14,7 @@ class OpptjeningAssemblerForUserGroups123Test : ShouldSpec({
     should("returnere andel pensjon basert på beholdning = 0") {
         Arrange.security()
 
-        OpptjeningAssemblerForUserGroups123(mockk()).createResponse(
+        OpptjeningAssemblerForUserGroups123().createResponse(
             Person(
                 pid = generatePidAtAge(50),
                 fornavn = null,

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningAssemblerForUserGroup4Test.kt
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningAssemblerForUserGroup4Test.kt
@@ -2,7 +2,6 @@ package no.nav.pensjon.selvbetjeningopptjening.opptjening
 
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
-import io.mockk.mockk
 import no.nav.pensjon.selvbetjeningopptjening.PidGenerator.generatePid
 import no.nav.pensjon.selvbetjeningopptjening.mock.TestObjects.emptyOpptjeningBasis
 import no.nav.pensjon.selvbetjeningopptjening.person.Foedselsdato2
@@ -30,7 +29,7 @@ class OpptjeningAssemblerForUserGroup4Test : ShouldSpec({
         expectedPerAar.keys.forEach {
             val foedselsdato = LocalDate.of(it, 5, 5)
 
-            OpptjeningAssemblerForUserGroup4(mockk()).createResponse(
+            OpptjeningAssemblerForUserGroup4().createResponse(
                 Person(
                     pid = generatePid(foedselsdato),
                     fornavn = null,

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningAssemblerForUserGroup5Test.kt
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningAssemblerForUserGroup5Test.kt
@@ -2,7 +2,6 @@ package no.nav.pensjon.selvbetjeningopptjening.opptjening
 
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
-import io.mockk.mockk
 import no.nav.pensjon.selvbetjeningopptjening.PidGenerator.generatePidAtAge
 import no.nav.pensjon.selvbetjeningopptjening.mock.TestObjects.emptyOpptjeningBasis
 import no.nav.pensjon.selvbetjeningopptjening.person.Foedselsdato2
@@ -15,7 +14,7 @@ class OpptjeningAssemblerForUserGroup5Test : ShouldSpec({
     should("returnere andel pensjon basert på beholdning = 10") {
         Arrange.security()
 
-        OpptjeningAssemblerForUserGroup5(mockk()).createResponse(
+        OpptjeningAssemblerForUserGroup5().createResponse(
             Person(
                 pid = generatePidAtAge(50),
                 fornavn = null,

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningAssemblerTest.kt
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/opptjening/OpptjeningAssemblerTest.kt
@@ -2,8 +2,6 @@ package no.nav.pensjon.selvbetjeningopptjening.opptjening
 
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.maps.shouldHaveSize
-import io.mockk.mockk
-import no.nav.pensjon.selvbetjeningopptjening.consumer.uttaksgrad.UttaksgradGetter
 
 class OpptjeningAssemblerTest : ShouldSpec({
 
@@ -14,16 +12,13 @@ class OpptjeningAssemblerTest : ShouldSpec({
             2020 to opptjening()
         )
 
-        TestOpptjeningAssembler(
-            getter = mockk<UttaksgradGetter>()
-        ).removeFutureOpptjening(opptjeningerByYear, 2019)
+        TestOpptjeningAssembler().removeFutureOpptjening(opptjeningerByYear, 2019)
 
         opptjeningerByYear shouldHaveSize 2
     }
 })
 
-private class TestOpptjeningAssembler(getter: UttaksgradGetter) :
-    OpptjeningAssembler(getter)
+private class TestOpptjeningAssembler : OpptjeningAssembler()
 
 private fun opptjening() =
     Opptjening(1L, 1.1)

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/tech/security/ingress/impersonal/ImpersonalAccessFilterTest.kt
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/tech/security/ingress/impersonal/ImpersonalAccessFilterTest.kt
@@ -10,10 +10,12 @@ import jakarta.servlet.ServletResponse
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import no.nav.pensjon.selvbetjeningopptjening.common.exception.NotFoundException
+import no.nav.pensjon.selvbetjeningopptjening.mock.TestObjects.jwt
 import no.nav.pensjon.selvbetjeningopptjening.mock.TestObjects.pid
 import no.nav.pensjon.selvbetjeningopptjening.tech.security.ingress.TargetPidExtractor
 import no.nav.pensjon.selvbetjeningopptjening.tech.security.ingress.impersonal.audit.Auditor
 import no.nav.pensjon.selvbetjeningopptjening.tech.security.ingress.impersonal.group.GroupMembershipService
+import no.nav.pensjon.selvbetjeningopptjening.testutil.Arrange
 
 class ImpersonalAccessFilterTest : ShouldSpec({
 
@@ -31,7 +33,27 @@ class ImpersonalAccessFilterTest : ShouldSpec({
         verify(exactly = 1) { chain.doFilter(request, response) }
     }
 
+    context("access as application") {
+        should("continue filter chain, no audit logging") {
+            Arrange.security(credentials = jwt(claims = mapOf("roles" to listOf("access_as_application"))))
+            val chain = mockk<FilterChain>(relaxed = true)
+            val request = arrangeRequest(pid = pid.pid, uri = "/api/foo")
+            val response = mockk<HttpServletResponse>(relaxed = true)
+            val auditor = mockk<Auditor>(relaxed = true)
+
+            ImpersonalAccessFilter(
+                pidGetter = arrangePid(),
+                groupMembershipService = arrangeTilgang(false),
+                auditor
+            ).doFilter(request, response, chain)
+
+            verify(exactly = 1) { chain.doFilter(request, response) }
+            verify { auditor wasNot Called }
+        }
+    }
+
     should("report 'forbidden' and break filter chain when innlogget bruker mangler gruppemedlemskap") {
+        Arrange.security()
         val chain = mockk<FilterChain>(relaxed = true)
         val request = arrangeRequest(pid = pid.pid, uri = "/api/foo")
         val response = mockk<HttpServletResponse>(relaxed = true)
@@ -47,6 +69,7 @@ class ImpersonalAccessFilterTest : ShouldSpec({
     }
 
     should("report 'not found' and break filter chain when person not found") {
+        Arrange.security()
         val chain = mockk<FilterChain>(relaxed = true)
         val request = arrangeRequest(pid = pid.pid, uri = "/api/foo")
         val response = mockk<HttpServletResponse>(relaxed = true)
@@ -62,6 +85,7 @@ class ImpersonalAccessFilterTest : ShouldSpec({
     }
 
     should("log audit info and continue filter chain when innlogget bruker har tilgang") {
+        Arrange.security()
         val chain = mockk<FilterChain>(relaxed = true)
         val auditor = mockk<Auditor>(relaxed = true)
         val request = arrangeRequest(pid = pid.pid, uri = "/foo")
@@ -79,23 +103,17 @@ class ImpersonalAccessFilterTest : ShouldSpec({
 })
 
 private fun arrangePid(): TargetPidExtractor =
-    mockk<TargetPidExtractor>().apply {
-        every { pid() } returns pid
-    }
+    mockk { every { pid() } returns pid }
 
 private fun arrangeRequest(pid: String?, uri: String): HttpServletRequest =
-    mockk<HttpServletRequest>().apply {
+    mockk {
         every { getHeader("pid") } returns pid
         every { getParameter("pid") } returns pid
         every { requestURI } returns uri
     }
 
 private fun arrangeTilgang(harTilgang: Boolean): GroupMembershipService =
-    mockk<GroupMembershipService>().apply {
-        every { innloggetBrukerHarTilgang(pid) } returns harTilgang
-    }
+    mockk { every { innloggetBrukerHarTilgang(pid) } returns harTilgang }
 
 private fun arrangeMissingPerson(): GroupMembershipService =
-    mockk<GroupMembershipService>().apply {
-        every { innloggetBrukerHarTilgang(pid) } throws NotFoundException("person")
-    }
+    mockk { every { innloggetBrukerHarTilgang(pid) } throws NotFoundException("person") }

--- a/src/test/java/no/nav/pensjon/selvbetjeningopptjening/testutil/Arrange.kt
+++ b/src/test/java/no/nav/pensjon/selvbetjeningopptjening/testutil/Arrange.kt
@@ -17,15 +17,14 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.authentication.TestingAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
-import kotlin.jvm.java
 
 object Arrange {
 
-    fun security() {
+    fun security(credentials: Any = jwt) {
         SecurityContextHolder.setContext(SecurityContextHolder.createEmptyContext())
 
         SecurityContextHolder.getContext().authentication = EnrichedAuthentication(
-            initialAuth = TestingAuthenticationToken("TEST_USER", jwt),
+            initialAuth = TestingAuthenticationToken("TEST_USER", credentials),
             egressTokenSuppliersByService = EgressTokenSuppliersByService(mapOf()),
             target = RepresentasjonTarget(pid, rolle = RepresentertRolle.SELV),
             authType = AuthType.PERSON_SELF


### PR DESCRIPTION
Nytt endepunkt for å hente ut opptjeningsmerknader per år. Dette behøves i pensjonskalkulator for interne brukere.
Dette er en app-til-app-tjeneste, så legger derfor til støtte for JWT-rollen `access_as_application`.

NB: Endringen påvirker implementasjonen av den eksisterende `opptjening`-tjenesten:
Henter `uttaksgraderForBeholdningAfter2009` istedenfor å bruke `uttaksgradGetter` som argument. Dette gjør at data hentes på en konsekvent måte og forenkler klassestrukturen.

Pluss opprydding:

- Fjerner `NO_NAV_SECURITY_JWT_ISSUER_SELVBETJENING_COOKIE_NAME` (utdatert)
- Fjerner unødvendige `cluster`-angivelser
